### PR TITLE
Win32 parallel fixes

### DIFF
--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -1261,7 +1261,7 @@ use File::Glob qw(:case);
     },
 
     'Time::HiRes' => {
-        'DISTRIBUTION' => 'ZEFRAM/Time-HiRes-1.9726.tar.gz',
+        'DISTRIBUTION' => 'RJBS/Time-HiRes-1.9727_02.tar.gz',
         'FILES'        => q[cpan/Time-HiRes],
     },
 

--- a/README.win32
+++ b/README.win32
@@ -99,13 +99,12 @@ You need a "make" program to build the sources.  If you are using
 Visual C++ or the Windows SDK tools, you can use nmake supplied with Visual C++
 or Windows SDK. You may also use, for Visual C++ or Windows SDK, dmake instead
 of nmake.  dmake is open source software, but is not included with Visual C++ or
-Windows SDK.  If you want parallel building with Visual C++ or
-Windows SDK you must use dmake instead of nmake.  Builds using gcc need dmake.
-nmake is not supported for gcc builds.  gmake is not supported, but might be
-added in the future.  It is recommended to use dmake 4.13 or newer for parallel
-building.  Older dmakes, in parallel mode, have very high CPU usage and pound
-the disk/filing system with duplicate I/O calls in an aggressive polling
-loop.
+Windows SDK.  Builds using gcc need dmake or gmake.  nmake is not supported for
+gcc builds.  gmake only supports gcc builds, not any other compiler.
+Parallel building is only supported with dmake with any compiler.  It is
+recommended to use dmake 4.13 or newer for parallel building.  Older dmakes,
+in parallel mode, have very high CPU usage and pound the disk/filing system
+with duplicate I/O calls in an aggressive polling loop.
 
 A port of dmake for Windows is available from:
 

--- a/cpan/Time-HiRes/HiRes.pm
+++ b/cpan/Time-HiRes/HiRes.pm
@@ -23,7 +23,7 @@ our @EXPORT_OK = qw (usleep sleep ualarm alarm gettimeofday time tv_interval
 		 stat lstat
 		);
 
-our $VERSION = '1.9726';
+our $VERSION = '1.9727_02';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 
@@ -510,7 +510,7 @@ modglobal hash:
 
   name             C prototype
   ---------------  ----------------------
-  Time::NVtime     double (*)()
+  Time::NVtime     NV (*)()
   Time::U2time     void (*)(pTHX_ UV ret[2])
 
 Both functions return equivalent information (like C<gettimeofday>)
@@ -521,12 +521,12 @@ VMS have emulations for it.)
 
 Here is an example of using C<NVtime> from C:
 
-  double (*myNVtime)(); /* Returns -1 on failure. */
+  NV (*myNVtime)(); /* Returns -1 on failure. */
   SV **svp = hv_fetch(PL_modglobal, "Time::NVtime", 12, 0);
   if (!svp)         croak("Time::HiRes is required");
   if (!SvIOK(*svp)) croak("Time::NVtime isn't a function pointer");
-  myNVtime = INT2PTR(double(*)(), SvIV(*svp));
-  printf("The current time is: %f\n", (*myNVtime)());
+  myNVtime = INT2PTR(NV(*)(), SvIV(*svp));
+  printf("The current time is: %" NVff "\n", (*myNVtime)());
 
 =head1 DIAGNOSTICS
 

--- a/cpan/Time-HiRes/Makefile.PL
+++ b/cpan/Time-HiRes/Makefile.PL
@@ -153,8 +153,10 @@ __EOD__
 	    if ( $ok && exists $args{run} && $args{run}) {
 		my $tmp_exe =
 		    File::Spec->catfile(File::Spec->curdir, $tmp_exe);
+		my @run = $tmp_exe;
+		unshift @run, $Config{run} if $Config{run} && -e $Config{run};
 		printf "Running $tmp_exe..." if $VERBOSE;
-		if (system($tmp_exe) == 0) {
+		if (system(@run) == 0) {
 		    $ok = 1;
 		} else {
 		    $ok = 0;

--- a/cpan/Time-HiRes/t/itimer.t
+++ b/cpan/Time-HiRes/t/itimer.t
@@ -43,7 +43,9 @@ note "setitimer: ", join(" ",
 
 # Assume interval timer granularity of $limit * 0.5 seconds.  Too bold?
 my $virt = Time::HiRes::getitimer(&Time::HiRes::ITIMER_VIRTUAL);
-ok defined $virt && abs($virt / 0.5) - 1 < $limit;
+ok(defined $virt && abs($virt / 0.5) - 1 < $limit,
+   "ITIMER_VIRTUAL defined with sufficient granularity")
+   or diag "virt=" . (defined $virt ? $virt : 'undef');
 
 note "getitimer: ", join(" ",
     Time::HiRes::getitimer(&Time::HiRes::ITIMER_VIRTUAL));
@@ -57,7 +59,8 @@ note "getitimer: ", join(" ",
     Time::HiRes::getitimer(&Time::HiRes::ITIMER_VIRTUAL));
 
 $virt = Time::HiRes::getitimer(&Time::HiRes::ITIMER_VIRTUAL);
-ok defined $virt && $virt == 0;
+note "at end, i=$i";
+is($virt, 0, "time left should be zero");
 
 $SIG{VTALRM} = 'DEFAULT';
 

--- a/ext/Config/Makefile.PL
+++ b/ext/Config/Makefile.PL
@@ -4,3 +4,15 @@ WriteMakefile(
     'VERSION_FROM'	=> 'Config.pm',
     'PL_FILES'		=> {'Config_xs.PL' => 'Config.xs'},
 );
+
+package MY;
+sub postamble {
+    #Config.xs is a psuedotarget in nmake, not a disk file, in nmake
+    #inference rules are triggered only by disk files with the same base name,
+    #not psuedotargets with the same base name, so specify the dependency
+    #explicitly, dmake doesn't need this
+    return $_[0]->is_make_type('nmake')
+        ? '$(OBJECT) : Config.c'."\n\n".'Config.c : Config.xs'
+        : '';
+}
+package main;

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -616,13 +616,13 @@ $(o).dll:
 
 # makedef.pl must be updated if this changes, and this should normally
 # only change when there is an incompatible revision of the public API.
-PERLIMPLIB	= ..\perl522.lib
-PERLSTATICLIB	= ..\perl522s.lib
-PERLDLL		= ..\perl522.dll
+PERLIMPLIB	= ..\cperl522.lib
+PERLSTATICLIB	= ..\cperl522s.lib
+PERLDLL		= ..\cperl522.dll
 
 MINIPERL	= ..\miniperl.exe
 MINIDIR		= .\mini
-PERLEXE		= ..\perl.exe
+PERLEXE		= ..\cperl.exe
 WPERLEXE	= ..\wperl.exe
 PERLEXESTATIC	= ..\perl-static.exe
 GLOBEXE		= ..\perlglob.exe

--- a/win32/Makefile.ce
+++ b/win32/Makefile.ce
@@ -569,12 +569,12 @@ $(o).dll:
 	$(RSC) -i.. $<
 
 # This must be relative to ../lib/CORE, else the ext dll build fails...
-PERLIMPLIB_EXP	= perl$(PV).lib
-PERLIMPLIB	= $(PERLCEDIR)\$(MACHINE)\perl$(PV).lib
-PERLDLL		= $(MACHINE)\perl$(PV).dll
+PERLIMPLIB_EXP	= cperl$(PV).lib
+PERLIMPLIB	= $(PERLCEDIR)\$(MACHINE)\cperl$(PV).lib
+PERLDLL		= $(MACHINE)\cperl$(PV).dll
 
 DLLDIR          = $(MACHINE)\dll
-PERLEXE		= $(MACHINE)\perl.exe
+PERLEXE		= $(MACHINE)\cperl.exe
 
 CONFIGPM	= ..\lib\Config.pm ..\lib\Config_heavy.pl
 GENUUDMAP	= ..\generate_uudmap.exe

--- a/win32/makefile.mk
+++ b/win32/makefile.mk
@@ -1059,15 +1059,11 @@ CFG_VARS	=					\
 
 all : CHECKDMAKE  rebasePE $(UNIDATAFILES) Extensions_nonxs $(PERLSTATIC)
 
-regnodes : ..\regnodes.h
-
 ..\regcomp$(o) : ..\regnodes.h ..\regcharclass.h
 
 ..\regexec$(o) : ..\regnodes.h ..\regcharclass.h
 
-reonly : regnodes .\config.h ..\git_version.h $(GLOBEXE) $(MINIPERL)	\
-	$(CONFIGPM) $(UNIDATAFILES) $(PERLEXE)				\
-	Extensions_reonly
+reonly : ..\regnodes.h $(UNIDATAFILES) Extensions_reonly
 
 static: $(PERLEXESTATIC)
 
@@ -1456,21 +1452,21 @@ $(PERLEXESTATIC): $(PERLSTATICLIB) $(CONFIGPM) $(PERLEXEST_OBJ) $(PERLEXE_RES)
 # DynaLoader.pm, so this will have to do
 
 #most of deps of this target are in DYNALOADER and therefore omitted here
-Extensions : $(PERLDEP) $(DYNALOADER)
+Extensions : $(PERLDEP) $(DYNALOADER) $(GLOBEXE)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --dynamic
 
 Extensions_reonly : $(PERLDEP) $(DYNALOADER)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --dynamic +re
 
-Extensions_static : ..\make_ext.pl ..\lib\buildcustomize.pl list_static_libs.pl $(CONFIGPM) $(HAVE_COREDIR)
+Extensions_static : ..\make_ext.pl list_static_libs.pl $(CONFIGPM) $(GLOBEXE) $(HAVE_COREDIR)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --static
 	$(MINIPERL) -I..\lib list_static_libs.pl > Extensions_static
 
-Extensions_nonxs : ..\make_ext.pl ..\lib\buildcustomize.pl $(CONFIGPM) ..\pod\perlfunc.pod
+Extensions_nonxs : ..\make_ext.pl ..\pod\perlfunc.pod $(CONFIGPM) $(GLOBEXE)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(CPANDIR) --dir=$(DISTDIR) --dir=$(EXTDIR) --nonxs !libs
 
 #lib must be built, it can't be buildcustomize.pl-ed, and is required for XS building
-$(DYNALOADER) : ..\make_ext.pl ..\lib\buildcustomize.pl $(CONFIGPM) $(HAVE_COREDIR)
+$(DYNALOADER) : ..\make_ext.pl $(CONFIGPM) $(HAVE_COREDIR)
 	$(MINIPERL) -I..\lib ..\make_ext.pl "MAKE=$(PLMAKE)" --dir=$(EXTDIR) --dir=$(DISTDIR) --dynaloader lib
 
 Extensions_clean :


### PR DESCRIPTION
Additional backports from p5p required for win32 parallel building to happen.

```
Test Summary Report
-------------------
comp/require.t                                                  (Wstat: 0 Tests:
 57 Failed: 1)
  Failed test:  52
op/signatures.t                                                 (Wstat: 0 Tests:
 1164 Failed: 0)
  TODO passed:   1041
porting/podcheck.t                                              (Wstat: 0 Tests:
 1354 Failed: 2)
  Failed tests:  178, 941
../dist/Math-BigRat/t/biglog.t                                  (Wstat: 1280 Tes
ts: 9 Failed: 0)
  Non-zero exit status: 5
  Parse errors: Bad plan.  You planned 17 tests but ran 9.
Files=2395, Tests=705409, 1667 wallclock secs (84.11 usr +  5.11 sys = 89.22 CPU
)
Result: FAIL
dmake:  Error code 131, while making 'test'
```

porting/podcheck.t was fixed already in rurban master I think. 

Without this PR, anyone trying a dmake win32 build gets

```
cl -c           -nologo -GF -W3 -O1 -MD -Zi -DNDEBUG -GL -DWIN32 -D_CONSOLE -DNO
_STRICT -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -D_U
SE_32BIT_TIME_T -O1 -MD -Zi -DNDEBUG -GL          -DVERSION=\"1.9726\"  -DXS_VER
SION=\"1.9726\"  "-I..\..\lib\CORE"  -DSELECT_IS_BROKEN -DATLEASTFIVEOHOHFIVE Hi
Res.c
HiRes.c
HiRes.xs(734) : error C2065: 'dTHXR' : undeclared identifier
HiRes.xs(1287) : error C2065: 'aTHXR' : undeclared identifier
HiRes.xs(1287) : warning C4047: 'function' : 'PerlInterpreter *' differs in leve
ls of indirection from 'int'
dmake:  Error code 130, while making 'HiRes.obj'
cl -c           -nologo -GF -W3 -O1 -MD -Zi -DNDEBUG -GL -DWIN32 -D_CONSOLE -DNO
_STRICT -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -D_U
SE_32BIT_TIME_T -O1 -MD -Zi -DNDEBUG -GL          -DVERSION=\"1.9726\"  -DXS_VER
SION=\"1.9726\"  "-I..\..\lib\CORE"  -DSELECT_IS_BROKEN -DATLEASTFIVEOHOHFIVE Hi
Res.c
HiRes.c
HiRes.xs(734) : error C2065: 'dTHXR' : undeclared identifier
HiRes.xs(1287) : error C2065: 'aTHXR' : undeclared identifier
HiRes.xs(1287) : warning C4047: 'function' : 'PerlInterpreter *' differs in leve
ls of indirection from 'int'
dmake:  Error code 130, while making 'HiRes.obj'
Unsuccessful make(cpan/Time-HiRes): code=65280 at ..\make_ext.pl line 575.
dmake:  Error code 130, while making 'Extensions'
```

and random race condition failures in parallel mode due to perlglob.exe being missing.
