### PR TITLE
Configxsrefactor

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3587,7 +3587,7 @@ ext/Config/Config_xs.out	gperf expanded Config.xs template with empty values
 ext/Config/Config_xs.PL		Update Config.xs and Config_xs.in
 ext/Config/Dummy.c		XS Config empty C file
 ext/Config/Makefile.PL		XS Config extension makefile writer
-ext/Config/typemap		XS Config Typemap
+ext/Config/typemap		XS Config extension typemap
 ext/Devel-Peek/Changes		Data debugging tool, changelog
 ext/Devel-Peek/Peek.pm		Data debugging tool, module and pod
 ext/Devel-Peek/Peek.xs		Data debugging tool, externals

--- a/MANIFEST
+++ b/MANIFEST
@@ -3587,6 +3587,7 @@ ext/Config/Config_xs.out	gperf expanded Config.xs template with empty values
 ext/Config/Config_xs.PL		Update Config.xs and Config_xs.in
 ext/Config/Dummy.c		XS Config empty C file
 ext/Config/Makefile.PL		XS Config extension makefile writer
+ext/Config/typemap		XS Config Typemap
 ext/Devel-Peek/Changes		Data debugging tool, changelog
 ext/Devel-Peek/Peek.pm		Data debugging tool, module and pod
 ext/Devel-Peek/Peek.xs		Data debugging tool, externals

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -229,6 +229,7 @@ use File::Glob qw(:case);
                  ext/Config/Config_xs.{in,out,PL}
                  ext/Config/Dummy.c
                  ext/Config/Makefile.PL
+                 ext/Config/typemap
         ],
     },
 

--- a/ext/Config/Config.pm
+++ b/ext/Config/Config.pm
@@ -56,8 +56,7 @@ sub import {
 }
 
 sub TIEHASH {
-    $_[1] = {} unless $_[1];
-    bless $_[1], $_[0];
+    bless \do{my $uv = 0;}, $_[0]; #XS Config Obj constructor
 }
 sub DESTROY { }
 sub STORE  { die "\%Config::Config is read-only\n" }

--- a/ext/Config/Config_xs.PL
+++ b/ext/Config/Config_xs.PL
@@ -228,6 +228,7 @@ sub post_process_gperf {
   my $in = shift;
   my $tmp = $in.".tmp";
   open my $OUT, '>', $tmp or die "Can't write '$tmp': $!";
+  binmode $OUT;
   local $/ = "\n\n";
   print $OUT <<'EOT';
 /* ex: set ro ft=c: -*- buffer-read-only: t; mode: c; c-basic-offset: 4; -*-

--- a/ext/Config/Config_xs.PL
+++ b/ext/Config/Config_xs.PL
@@ -269,6 +269,8 @@ __inline
 
     # There should be at least one space between a C keyword and any subsequent open parenthesis
     s/sizeof\(/sizeof (/g;
+    # don't delete line numbers, pointing to Config_xs.in
+    # s/^#line \d+ .+$//gm;
 
     print $OUT $_;
   }

--- a/ext/Config/Config_xs.in
+++ b/ext/Config/Config_xs.in
@@ -60,7 +60,7 @@ enum Config_types {
     T_INT,
 };
 
-struct Perl_Config { int name; signed char type; size_t len; const char *value; };
+struct Perl_Config { U16 name; signed char type; size_t len; const char *value; };
 static const struct Perl_Config *
 Config_lookup (register const char *str, register unsigned int len);
 
@@ -1300,6 +1300,11 @@ zip,			T_STR,	0,"@@zip@@"
 
 MODULE = Config		PACKAGE = Config
 PROTOTYPES: DISABLE
+
+BOOT:
+{
+    STATIC_ASSERT_STMT(sizeof(stringpool_contents) <= U16_MAX);
+}
 
 void
 FETCH(self, key)

--- a/ext/Config/Config_xs.in
+++ b/ext/Config/Config_xs.in
@@ -45,6 +45,14 @@ API function to access the generated hash.
 #include "perl.h"
 #include "XSUB.h"
 
+/* Inside of tied XS object is a SVUV which is the iterator for the tied hash.
+   The iterator is the offset of next stringpool string to read, unless the
+   iterating is finished, then offset is beyond the end of stringpool and should
+   not be used to deref (read) the string pool, until the next FIRSTKEY which
+   resets the offset back to 0 or offset of 2nd string in string pool */
+
+typedef UV CFGSELF; /* for typemap */
+
 enum Config_types {
     T_EMP, /* "" */
     T_BOO,  /* "0" for undef or "1" for define */
@@ -53,7 +61,7 @@ enum Config_types {
 };
 
 struct Perl_Config { int name; signed char type; size_t len; const char *value; };
-const struct Perl_Config *
+static const struct Perl_Config *
 Config_lookup (register const char *str, register unsigned int len);
 
 %}
@@ -1290,99 +1298,130 @@ zcat,			T_STR,	0,"@@zcat@@"
 zip,			T_STR,	0,"@@zip@@"
 %%
 
-int g_iterpos = 0;
-
 MODULE = Config		PACKAGE = Config
 PROTOTYPES: DISABLE
 
-SV*
+void
 FETCH(self, key)
      SV* self
      SV* key
-CODE:
-     const struct Perl_Config *c = Config_lookup(SvPVX_const(key), SvCUR(key));
+PREINIT:
+     const struct Perl_Config *c;
+     SV * RETVAL;
+PPCODE:
+     SP++; /* make space for 1 returned SV* */
+     PUTBACK; /* let some vars go out of liveness */
+
+     c = Config_lookup(SvPVX_const(key), SvCUR(key));
      PERL_UNUSED_VAR(self);
      if (!c)
-         XSRETURN_UNDEF;
+         goto return_undef;
      if (c->type == T_EMP)
-         RETVAL = newSVpv_share("", 0);
-     else if (c->type == T_BOO)
-         RETVAL = *(c->value) == '0' ? &PL_sv_undef
-                                     : SvREFCNT_inc_NN(SV_CONST(define));
-     else if (c->type == T_INT)
+         RETVAL = &PL_sv_no;
+     else if (c->type == T_BOO) {
+         if(*(c->value) == '0')
+              return_undef:
+              RETVAL = &PL_sv_undef;
+         else
+              RETVAL = SV_CONST(define); /* this SV * never goes away once vivified */
+     }
+     else if (c->type == T_INT) {
 #ifdef HAS_STRTOL
          RETVAL = newSViv(strtol(c->value,NULL,10));
 #else
          RETVAL = newSViv(atoi(c->value));
 #endif
+         RETVAL = sv_2mortal(RETVAL);
+     }
      else
          /* TODO: store len also in struct */
-         RETVAL = newSVpvn(c->value, c->len);
-OUTPUT:
-    RETVAL
+         RETVAL = newSVpvn_flags(c->value, c->len, SVs_TEMP);
+     *SP = RETVAL;
+     return; /* skip implicit PUTBACK, it was done earlier */
 
-IV
-SCALAR(self = NULL)
-         SV *self
-CODE:
-    PERL_UNUSED_VAR(self);
+#you would think the prototype croak can be removed and replaced with ...
+#but the check actually makes sure there is 1 SP slot available since the retval
+#SV* winds up ontop of the incoming self arg
+void
+SCALAR(self)
+    SV *self
+PPCODE:
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
+    /* perfect hash is perfect */
+    *SP = newSVpvn_flags(STRINGIFY(TOTAL_KEYWORDS) "/" STRINGIFY(TOTAL_KEYWORDS),
+                         sizeof(STRINGIFY(TOTAL_KEYWORDS) "/" STRINGIFY(TOTAL_KEYWORDS))-1,
+                         SVs_TEMP);
+    return; /* skip implicit PUTBACK, it was done earlier */
+
+#1st arg could be self in the future
+#KEYS doesnt exist in tied hash API
+void
+KEYS(...)
+PREINIT:
     /* Note: This is highly gperf dependent */
-    RETVAL = TOTAL_KEYWORDS;
-OUTPUT:
-    RETVAL
+    const int size = TOTAL_KEYWORDS;
+    const char *s = (const char *)stringpool;
+    const char * const end = (char *)stringpool+sizeof(stringpool_contents);
+PPCODE:
+    const I32 gimme = GIMME_V;
+    if(gimme != G_VOID) {
+        EXTEND(sp,  gimme == G_SCALAR ? 1 : size);
+        if(gimme == G_SCALAR) {
+            mPUSHu(size); /* return just length */
+        } else {
+            int i = 0; /* optimized away */
+            while (s < end) {
+                int l = strlen(s);
+                const char * const current_s = s; /* reduce liveness of var l */
+                s += l+1; /* set string up for next read */
+                i++; /* sanity test */
+                mPUSHp(current_s, l);
+            }
+            assert(i == size);
+        }
+    } /* return nothing for void */
 
 void
-KEYS(self = NULL)
-         SV *self
+FIRSTKEY(self)
+         CFGSELF *self
 PREINIT:
-    int i;
     /* Note: This is highly gperf dependent */
-    const int size = TOTAL_KEYWORDS;
-    char *s = (char *)stringpool;
+    const char *s = (const char *)stringpool;
+    size_t len;
 PPCODE:
-    PERL_UNUSED_VAR(self);
-    EXTEND(sp, size);
-    for (i=0; i<size; i++) {
-        int l = strlen(s);
-        mPUSHp(s, l);
-        s += l+1;
-    }
+    STATIC_ASSERT_STMT(sizeof(stringpool_contents) > 1); /* atleast 1 string */
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
 
-SV*
-FIRSTKEY(self = NULL)
-         SV *self
-PREINIT:
-    /* Note: This is highly gperf dependent */
-    char *s = (char *)stringpool;
-CODE:
-    PERL_UNUSED_VAR(self);
-    g_iterpos = 0; /* self is a singleton */
-    RETVAL = newSVpvn(s, strlen(s));
-OUTPUT:
-    RETVAL
+    len = strlen(s);
+    /* self is SVIV with offset (aka iterator) into stringpool */
+    *self = len + 1; /* set to next string to read */
+    *SP = newSVpvn_flags(s, len, SVs_TEMP);
+    return; /* skip implicit PUTBACK, it was done earlier */
 
-SV*
-NEXTKEY(self = NULL, lastkey = NULL)
-         SV *self
+void
+NEXTKEY(self, lastkey)
+         CFGSELF *self
          SV *lastkey
 PREINIT:
-    int i;
-    /* Note: This is highly gperf dependent */
-    const int size = TOTAL_KEYWORDS;
-    char *s = (char *)stringpool;
-CODE:
-    PERL_UNUSED_VAR(self);
+    SV * RETVAL;
+PPCODE:
     PERL_UNUSED_VAR(lastkey);
-    g_iterpos++;
-    if (g_iterpos >= size)
-        XSRETURN_UNDEF;
-    for (i=0; i<g_iterpos; i++) {
-        int l = strlen(s);
-        s += l+1;
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
+
+    /* bounds check to avoid running off the end of stringpool */
+    if (*self < sizeof(stringpool_contents)) {
+        const char * key = (const char*)stringpool+*self;
+        size_t len = strlen(key);
+        *self += len + 1;
+        RETVAL = newSVpvn_flags(key, len, SVs_TEMP);
     }
-    RETVAL = newSVpvn(s, strlen(s));
-OUTPUT:
-    RETVAL
+    else
+        RETVAL = &PL_sv_undef;
+    *SP = RETVAL;
+    return; /* skip implicit PUTBACK, it was done earlier */
 
 void
 EXISTS(self, key)

--- a/ext/Config/Config_xs.in
+++ b/ext/Config/Config_xs.in
@@ -1354,8 +1354,8 @@ PPCODE:
                          SVs_TEMP);
     return; /* skip implicit PUTBACK, it was done earlier */
 
-#1st arg could be self in the future
-#KEYS doesnt exist in tied hash API
+# 1st arg could be self in the future
+# Note: KEYS doesnt exist in tied hash API, only FIRSTKEY/NEXTKEY
 void
 KEYS(...)
 PREINIT:

--- a/ext/Config/Config_xs.out
+++ b/ext/Config/Config_xs.out
@@ -80,6 +80,14 @@ API function to access the generated hash.
 #include "perl.h"
 #include "XSUB.h"
 
+/* Inside of tied XS object is a SVUV which is the iterator for the tied hash.
+   The iterator is the offset of next stringpool string to read, unless the
+   iterating is done, then offset is beyond the end of stringpool and should
+   not be used to deref (read) the string pool, until the next FIRSTKEY which
+   resets the offset back to 0 or offset of 2nd string in string pool */
+
+typedef UV CFGSELF;
+
 enum Config_types {
     T_EMP, /* "" */
     T_BOO,  /* "0" for undef or "1" for define */
@@ -88,10 +96,10 @@ enum Config_types {
 };
 
 struct Perl_Config { int name; signed char type; size_t len; const char *value; };
-const struct Perl_Config *
+static const struct Perl_Config *
 Config_lookup (register const char *str, register unsigned int len);
 
-#line 67 "ext/Config/Config_xs.in"
+#line 75 "ext/Config/Config_xs.in"
 struct Perl_Config;
 
 #define TOTAL_KEYWORDS 1222
@@ -2651,3313 +2659,3313 @@ Config_lookup (register const char *str, register unsigned int len)
   static const struct Perl_Config wordlist[] =
     {
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 73 "ext/Config/Config_xs.in"
+#line 81 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7,			T_EMP,	0,"@@Id@@"},
-#line 1107 "ext/Config/Config_xs.in"
+#line 1115 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8,			T_STR,	0,"@@sed@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1195 "ext/Config/Config_xs.in"
+#line 1203 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str13,			T_STR,	0,"@@tee@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1202 "ext/Config/Config_xs.in"
+#line 1210 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str17,			T_STR,	0,"@@tr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1196 "ext/Config/Config_xs.in"
+#line 1204 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str24,			T_STR,	0,"@@test@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 70 "ext/Config/Config_xs.in"
+#line 78 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str36,			T_STR,	0,"@@CONFIG@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 987 "ext/Config/Config_xs.in"
+#line 995 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str42,			T_STR,	0,"@@ls@@"},
       {-1, -1, 0, NULL},
-#line 955 "ext/Config/Config_xs.in"
+#line 963 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str44,			T_STR,	0,"@@less@@"},
-#line 87 "ext/Config/Config_xs.in"
+#line 95 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str45,		T_INT,	0,"@@SUBVERSION@@"},
       {-1, -1, 0, NULL},
-#line 948 "ext/Config/Config_xs.in"
+#line 956 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str47,			T_STR,	0,"@@ld@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1063 "ext/Config/Config_xs.in"
+#line 1071 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str52,			T_STR,	0,"@@pr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1156 "ext/Config/Config_xs.in"
+#line 1164 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str57,			T_STR,	0,"@@so@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 83 "ext/Config/Config_xs.in"
+#line 91 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str65,	T_INT,	0,"@@PERL_SUBVERSION@@"},
       {-1, -1, 0, NULL},
-#line 1200 "ext/Config/Config_xs.in"
+#line 1208 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str67,			T_STR,	0,"@@to@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 92 "ext/Config/Config_xs.in"
+#line 100 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str72,			T_STR,	0,"@@_o@@"},
       {-1, -1, 0, NULL},
-#line 1160 "ext/Config/Config_xs.in"
+#line 1168 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str74,			T_STR,	0,"@@sort@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 81 "ext/Config/Config_xs.in"
+#line 89 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str80,	T_STR,	0,"@@PERL_PATCHLEVEL@@"},
       {-1, -1, 0, NULL},
-#line 84 "ext/Config/Config_xs.in"
+#line 92 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str82,		T_INT,	0,"@@PERL_VERSION@@"},
-#line 551 "ext/Config/Config_xs.in"
+#line 559 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str83,		T_BOO,	0,"@@d_select@@"},
-#line 80 "ext/Config/Config_xs.in"
+#line 88 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str84,		T_STR,	0,"@@PERL_CONFIG_SH@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 985 "ext/Config/Config_xs.in"
+#line 993 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str87,			T_STR,	0,"@@lp@@"},
-#line 411 "ext/Config/Config_xs.in"
+#line 419 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str88,		T_BOO,	0,"@@d_isless@@"},
       {-1, -1, 0, NULL},
-#line 1154 "ext/Config/Config_xs.in"
+#line 1162 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str90,			T_STR,	0,"@@sleep@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 986 "ext/Config/Config_xs.in"
+#line 994 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str93,			T_STR,	0,"@@lpr@@"},
-#line 1051 "ext/Config/Config_xs.in"
+#line 1059 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str94,			T_STR,	0,"@@perl@@"},
-#line 76 "ext/Config/Config_xs.in"
+#line 84 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str95,		T_INT,	0,"@@PATCHLEVEL@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 82 "ext/Config/Config_xs.in"
+#line 90 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str98,		T_INT,	0,"@@PERL_REVISION@@"},
       {-1, -1, 0, NULL},
-#line 635 "ext/Config/Config_xs.in"
+#line 643 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str100,		T_BOO,	0,"@@d_strerror@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 640 "ext/Config/Config_xs.in"
+#line 648 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str103,		T_BOO,	0,"@@d_strtod@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1016 "ext/Config/Config_xs.in"
+#line 1024 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str106,			T_STR,	0,"@@n@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 822 "ext/Config/Config_xs.in"
+#line 830 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str118,		T_BOO,	0,"@@i_dirent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 636 "ext/Config/Config_xs.in"
+#line 644 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str122,		T_BOO,	0,"@@d_strerror_r@@"},
-#line 863 "ext/Config/Config_xs.in"
+#line 871 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str123,		T_BOO,	0,"@@i_stdint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 503 "ext/Config/Config_xs.in"
+#line 511 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str126,			T_BOO,	0,"@@d_pipe@@"},
-#line 1095 "ext/Config/Config_xs.in"
+#line 1103 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str127,		T_STR,	0,"@@sPRId64@@"},
       {-1, -1, 0, NULL},
-#line 659 "ext/Config/Config_xs.in"
+#line 667 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str129,		T_BOO,	0,"@@d_telldir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1099 "ext/Config/Config_xs.in"
+#line 1107 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str132,		T_STR,	0,"@@sPRIi64@@"},
       {-1, -1, 0, NULL},
-#line 260 "ext/Config/Config_xs.in"
+#line 268 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str134,		T_BOO,	0,"@@d_dlerror@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 641 "ext/Config/Config_xs.in"
+#line 649 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str138,		T_BOO,	0,"@@d_strtol@@"},
-#line 642 "ext/Config/Config_xs.in"
+#line 650 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str139,		T_BOO,	0,"@@d_strtold@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 576 "ext/Config/Config_xs.in"
+#line 584 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str145,		T_BOO,	0,"@@d_setprior@@"},
-#line 852 "ext/Config/Config_xs.in"
+#line 860 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str146,			T_BOO,	0,"@@i_prot@@"},
-#line 973 "ext/Config/Config_xs.in"
+#line 981 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str147,			T_STR,	0,"@@ln@@"},
-#line 974 "ext/Config/Config_xs.in"
+#line 982 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str148,			T_STR,	0,"@@lns@@"},
       {-1, -1, 0, NULL},
-#line 1052 "ext/Config/Config_xs.in"
+#line 1060 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str150,			T_STR,	0,"@@perl5@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 634 "ext/Config/Config_xs.in"
+#line 642 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str154,		T_STR,	0,"@@d_strerrm@@"},
       {-1, -1, 0, NULL},
-#line 539 "ext/Config/Config_xs.in"
+#line 547 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str156,			T_BOO,	0,"@@d_rint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 970 "ext/Config/Config_xs.in"
+#line 978 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str159,			T_STR,	0,"@@line@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1203 "ext/Config/Config_xs.in"
+#line 1211 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str164,			T_STR,	0,"@@trnl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 971 "ext/Config/Config_xs.in"
+#line 979 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str169,			T_STR,	0,"@@lint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 187 "ext/Config/Config_xs.in"
+#line 195 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str174,		T_BOO,	0,"@@d_PRIXU64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1100 "ext/Config/Config_xs.in"
+#line 1108 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str177,		T_STR,	0,"@@sPRIo64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 102 "ext/Config/Config_xs.in"
+#line 110 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str182,			T_STR,	0,"@@ar@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 427 "ext/Config/Config_xs.in"
+#line 435 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str188,		T_BOO,	0,"@@d_llrint@@"},
-#line 71 "ext/Config/Config_xs.in"
+#line 79 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str189,			T_EMP,	0,"@@Date@@"},
       {-1, -1, 0, NULL},
-#line 72 "ext/Config/Config_xs.in"
+#line 80 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str191,			T_EMP,	0,"@@Header@@"},
-#line 90 "ext/Config/Config_xs.in"
+#line 98 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str192,			T_STR,	0,"@@_a@@"},
-#line 1186 "ext/Config/Config_xs.in"
+#line 1194 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str193,			T_STR,	0,"@@tar@@"},
-#line 703 "ext/Config/Config_xs.in"
+#line 711 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str194,			T_STR,	0,"@@date@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 89 "ext/Config/Config_xs.in"
+#line 97 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str200,			T_EMP,	0,"@@State@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 504 "ext/Config/Config_xs.in"
+#line 512 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str206,			T_BOO,	0,"@@d_poll@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 851 "ext/Config/Config_xs.in"
+#line 859 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str211,			T_BOO,	0,"@@i_poll@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 118 "ext/Config/Config_xs.in"
+#line 126 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str216,			T_STR,	0,"@@c@@"},
-#line 1170 "ext/Config/Config_xs.in"
+#line 1178 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str217,		T_STR,	0,"@@startsh@@"},
-#line 816 "ext/Config/Config_xs.in"
+#line 824 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str218,		T_BOO,	0,"@@i_assert@@"},
-#line 577 "ext/Config/Config_xs.in"
+#line 585 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str219,		T_BOO,	0,"@@d_setproctitle@@"},
       {-1, -1, 0, NULL},
-#line 618 "ext/Config/Config_xs.in"
+#line 626 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str221,			T_BOO,	0,"@@d_stat@@"},
       {-1, -1, 0, NULL},
-#line 1165 "ext/Config/Config_xs.in"
+#line 1173 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str223,			T_STR,	0,"@@src@@"},
-#line 527 "ext/Config/Config_xs.in"
+#line 535 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str224,		T_BOO,	0,"@@d_readdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1185 "ext/Config/Config_xs.in"
+#line 1193 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str239,			T_STR,	0,"@@tail@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 529 "ext/Config/Config_xs.in"
+#line 537 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str246,		T_BOO,	0,"@@d_readdir_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 660 "ext/Config/Config_xs.in"
+#line 668 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str249,		T_BOO,	0,"@@d_telldirproto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 259 "ext/Config/Config_xs.in"
+#line 267 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str258,		T_BOO,	0,"@@d_dladdr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 850 "ext/Config/Config_xs.in"
+#line 858 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str261,			T_BOO,	0,"@@i_niin@@"},
-#line 167 "ext/Config/Config_xs.in"
+#line 175 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str262,			T_STR,	0,"@@cp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 848 "ext/Config/Config_xs.in"
+#line 856 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str265,		T_BOO,	0,"@@i_neterrno@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1094 "ext/Config/Config_xs.in"
+#line 1102 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str268,		T_STR,	0,"@@sPRIXU64@@"},
       {-1, -1, 0, NULL},
-#line 712 "ext/Config/Config_xs.in"
+#line 720 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str270,			T_STR,	0,"@@dlsrc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 631 "ext/Config/Config_xs.in"
+#line 639 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str273,		T_BOO,	0,"@@d_strchr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1088 "ext/Config/Config_xs.in"
+#line 1096 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str276,		T_INT,	0,"@@sGMTIME_min@@"},
-#line 445 "ext/Config/Config_xs.in"
+#line 453 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str277,		T_BOO,	0,"@@d_lseekproto@@"},
-#line 188 "ext/Config/Config_xs.in"
+#line 196 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str278,		T_BOO,	0,"@@d_PRId64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 192 "ext/Config/Config_xs.in"
+#line 200 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str283,		T_BOO,	0,"@@d_PRIi64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1141 "ext/Config/Config_xs.in"
+#line 1149 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str292,		T_STR,	0,"@@sitelib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 498 "ext/Config/Config_xs.in"
+#line 506 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str297,		T_BOO,	0,"@@d_open3@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1105 "ext/Config/Config_xs.in"
+#line 1113 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str304,		T_STR,	0,"@@scriptdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 169 "ext/Config/Config_xs.in"
+#line 177 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str308,			T_STR,	0,"@@cpp@@"},
       {-1, -1, 0, NULL},
-#line 398 "ext/Config/Config_xs.in"
+#line 406 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str310,		T_BOO,	0,"@@d_inetntop@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 206 "ext/Config/Config_xs.in"
+#line 214 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str327,		T_BOO,	0,"@@d_asinh@@"},
-#line 193 "ext/Config/Config_xs.in"
+#line 201 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str328,		T_BOO,	0,"@@d_PRIo64@@"},
-#line 168 "ext/Config/Config_xs.in"
+#line 176 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str329,			T_STR,	0,"@@cpio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 490 "ext/Config/Config_xs.in"
+#line 498 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str356,			T_BOO,	0,"@@d_nice@@"},
       {-1, -1, 0, NULL},
-#line 528 "ext/Config/Config_xs.in"
+#line 536 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str358,		T_BOO,	0,"@@d_readdir64_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1056 "ext/Config/Config_xs.in"
+#line 1064 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str363,		T_STR,	0,"@@perllibs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 847 "ext/Config/Config_xs.in"
+#line 855 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str367,		T_BOO,	0,"@@i_netdb@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 412 "ext/Config/Config_xs.in"
+#line 420 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str372,		T_BOO,	0,"@@d_isnan@@"},
       {-1, -1, 0, NULL},
-#line 247 "ext/Config/Config_xs.in"
+#line 255 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str374,		T_BOO,	0,"@@d_ctermid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 248 "ext/Config/Config_xs.in"
+#line 256 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str396,		T_BOO,	0,"@@d_ctermid_r@@"},
-#line 1082 "ext/Config/Config_xs.in"
+#line 1090 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str397,			T_STR,	0,"@@rm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 120 "ext/Config/Config_xs.in"
+#line 128 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str403,			T_STR,	0,"@@cat@@"},
       {-1, -1, 0, NULL},
-#line 1080 "ext/Config/Config_xs.in"
+#line 1088 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str405,	T_INT,	0,"@@readdir_r_proto@@"},
-#line 614 "ext/Config/Config_xs.in"
+#line 622 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str406,		T_BOO,	0,"@@d_srand48_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 484 "ext/Config/Config_xs.in"
+#line 492 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str410,			T_BOO,	0,"@@d_nan@@"},
-#line 264 "ext/Config/Config_xs.in"
+#line 272 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str411,		T_BOO,	0,"@@d_drand48_r@@"},
       {-1, -1, 0, NULL},
-#line 413 "ext/Config/Config_xs.in"
+#line 421 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str413,		T_BOO,	0,"@@d_isnanl@@"},
       {-1, -1, 0, NULL},
-#line 552 "ext/Config/Config_xs.in"
+#line 560 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str415,			T_BOO,	0,"@@d_sem@@"},
-#line 720 "ext/Config/Config_xs.in"
+#line 728 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str416,			T_STR,	0,"@@dtrace@@"},
       {-1, -1, 0, NULL},
-#line 537 "ext/Config/Config_xs.in"
+#line 545 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str418,		T_BOO,	0,"@@d_rename@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 497 "ext/Config/Config_xs.in"
+#line 505 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str429,		T_BOO,	0,"@@d_oldsock@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 121 "ext/Config/Config_xs.in"
+#line 129 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str432,			T_STR,	0,"@@cc@@"},
       {-1, -1, 0, NULL},
-#line 1090 "ext/Config/Config_xs.in"
+#line 1098 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str434,		T_INT,	0,"@@sLOCALTIME_min@@"},
       {-1, -1, 0, NULL},
-#line 662 "ext/Config/Config_xs.in"
+#line 670 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str436,			T_BOO,	0,"@@d_time@@"},
-#line 540 "ext/Config/Config_xs.in"
+#line 548 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str437,		T_BOO,	0,"@@d_rmdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 898 "ext/Config/Config_xs.in"
+#line 906 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str441,			T_BOO,	0,"@@i_time@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 664 "ext/Config/Config_xs.in"
+#line 672 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str447,		T_BOO,	0,"@@d_times@@"},
       {-1, -1, 0, NULL},
-#line 1055 "ext/Config/Config_xs.in"
+#line 1063 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str449,		T_STR,	0,"@@perladmin@@"},
       {-1, -1, 0, NULL},
-#line 79 "ext/Config/Config_xs.in"
+#line 87 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str451,	T_INT,	0,"@@PERL_API_VERSION@@"},
-#line 77 "ext/Config/Config_xs.in"
+#line 85 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str452,	T_INT,	0,"@@PERL_API_REVISION@@"},
       {-1, -1, 0, NULL},
-#line 1009 "ext/Config/Config_xs.in"
+#line 1017 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str454,			T_STR,	0,"@@more@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 78 "ext/Config/Config_xs.in"
+#line 86 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str459,	T_INT,	0,"@@PERL_API_SUBVERSION@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 236 "ext/Config/Config_xs.in"
+#line 244 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str467,		T_BOO,	0,"@@d_class@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 200 "ext/Config/Config_xs.in"
+#line 208 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str482,		T_BOO,	0,"@@d_acosh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1228 "ext/Config/Config_xs.in"
+#line 1236 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str485,			T_BOO,	0,"@@usedl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 401 "ext/Config/Config_xs.in"
+#line 409 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str494,		T_BOO,	0,"@@d_ip_mreq@@"},
       {-1, -1, 0, NULL},
-#line 615 "ext/Config/Config_xs.in"
+#line 623 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str496,		T_BOO,	0,"@@d_srandom_r@@"},
-#line 1022 "ext/Config/Config_xs.in"
+#line 1030 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str497,			T_STR,	0,"@@nm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 207 "ext/Config/Config_xs.in"
+#line 215 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str502,		T_BOO,	0,"@@d_atanh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1173 "ext/Config/Config_xs.in"
+#line 1181 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str505,		T_STR,	0,"@@stdio_base@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 265 "ext/Config/Config_xs.in"
+#line 273 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str509,		T_BOO,	0,"@@d_drand48proto@@"},
       {-1, -1, 0, NULL},
-#line 624 "ext/Config/Config_xs.in"
+#line 632 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str511,	T_BOO,	0,"@@d_stdio_cnt_lval@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1079 "ext/Config/Config_xs.in"
+#line 1087 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str517,	T_INT,	0,"@@readdir64_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 619 "ext/Config/Config_xs.in"
+#line 627 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str520,		T_BOO,	0,"@@d_statblks@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 628 "ext/Config/Config_xs.in"
+#line 636 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str525,	T_BOO,	0,"@@d_stdio_stream_array@@"},
       {-1, -1, 0, NULL},
-#line 202 "ext/Config/Config_xs.in"
+#line 210 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str527,		T_BOO,	0,"@@d_alarm@@"},
       {-1, -1, 0, NULL},
-#line 643 "ext/Config/Config_xs.in"
+#line 651 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str529,		T_BOO,	0,"@@d_strtoll@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 647 "ext/Config/Config_xs.in"
+#line 655 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str539,		T_BOO,	0,"@@d_strtouq@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1085 "ext/Config/Config_xs.in"
+#line 1093 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str548,			T_STR,	0,"@@run@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1101 "ext/Config/Config_xs.in"
+#line 1109 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str557,		T_STR,	0,"@@sPRIu64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1163 "ext/Config/Config_xs.in"
+#line 1171 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str565,	T_INT,	0,"@@srand48_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1041 "ext/Config/Config_xs.in"
+#line 1049 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str568,		T_STR,	0,"@@optimize@@"},
       {-1, -1, 0, NULL},
-#line 719 "ext/Config/Config_xs.in"
+#line 727 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str570,	T_INT,	0,"@@drand48_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 718 "ext/Config/Config_xs.in"
+#line 726 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str572,		T_STR,	0,"@@drand01@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 909 "ext/Config/Config_xs.in"
+#line 917 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str577,		T_STR,	0,"@@incpath@@"},
-#line 1197 "ext/Config/Config_xs.in"
+#line 1205 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str578,		T_STR,	0,"@@timeincl@@"},
-#line 428 "ext/Config/Config_xs.in"
+#line 436 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str579,		T_BOO,	0,"@@d_llrintl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 283 "ext/Config/Config_xs.in"
+#line 291 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str583,		T_BOO,	0,"@@d_eunice@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 668 "ext/Config/Config_xs.in"
+#line 676 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str587,		T_BOO,	0,"@@d_trunc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1179 "ext/Config/Config_xs.in"
+#line 1187 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str591,	T_INT,	0,"@@strerror_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1089 "ext/Config/Config_xs.in"
+#line 1097 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str599,		T_INT,	0,"@@sLOCALTIME_max@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 845 "ext/Config/Config_xs.in"
+#line 853 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str603,		T_BOO,	0,"@@i_mntent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 566 "ext/Config/Config_xs.in"
+#line 574 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str606,		T_BOO,	0,"@@d_setitimer@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 990 "ext/Config/Config_xs.in"
+#line 998 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str619,			T_STR,	0,"@@mail@@"},
-#line 1155 "ext/Config/Config_xs.in"
+#line 1163 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str620,			T_STR,	0,"@@smail@@"},
       {-1, -1, 0, NULL},
-#line 441 "ext/Config/Config_xs.in"
+#line 449 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str622,		T_BOO,	0,"@@d_lrint@@"},
-#line 443 "ext/Config/Config_xs.in"
+#line 451 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str623,		T_BOO,	0,"@@d_lround@@"},
       {-1, -1, 0, NULL},
-#line 1084 "ext/Config/Config_xs.in"
+#line 1092 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str625,			T_STR,	0,"@@rmail@@"},
-#line 1023 "ext/Config/Config_xs.in"
+#line 1031 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str626,			T_STR,	0,"@@nm_opt@@"},
-#line 541 "ext/Config/Config_xs.in"
+#line 549 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str627,		T_BOO,	0,"@@d_round@@"},
-#line 670 "ext/Config/Config_xs.in"
+#line 678 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str628,		T_BOO,	0,"@@d_truncl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 166 "ext/Config/Config_xs.in"
+#line 174 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str633,		T_STR,	0,"@@contains@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 678 "ext/Config/Config_xs.in"
+#line 686 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str636,		T_BOO,	0,"@@d_unordered@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 198 "ext/Config/Config_xs.in"
+#line 206 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str643,		T_BOO,	0,"@@d_access@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1175 "ext/Config/Config_xs.in"
+#line 1183 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str649,		T_STR,	0,"@@stdio_cnt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1164 "ext/Config/Config_xs.in"
+#line 1172 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str655,	T_INT,	0,"@@srandom_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 442 "ext/Config/Config_xs.in"
+#line 450 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str663,		T_BOO,	0,"@@d_lrintl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1091 "ext/Config/Config_xs.in"
+#line 1099 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str675,		T_STR,	0,"@@sPRIEUldbl@@"},
-#line 1144 "ext/Config/Config_xs.in"
+#line 1152 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str676,		T_STR,	0,"@@siteman1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1093 "ext/Config/Config_xs.in"
+#line 1101 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str680,		T_STR,	0,"@@sPRIGUldbl@@"},
-#line 1146 "ext/Config/Config_xs.in"
+#line 1154 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str681,		T_STR,	0,"@@siteman3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 601 "ext/Config/Config_xs.in"
+#line 609 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str685,	T_BOO,	0,"@@d_sin6_scope_id@@"},
       {-1, -1, 0, NULL},
-#line 446 "ext/Config/Config_xs.in"
+#line 454 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str687,		T_BOO,	0,"@@d_lstat@@"},
       {-1, -1, 0, NULL},
-#line 251 "ext/Config/Config_xs.in"
+#line 259 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str689,		T_BOO,	0,"@@d_cuserid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 506 "ext/Config/Config_xs.in"
+#line 514 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str692,		T_BOO,	0,"@@d_prctl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 189 "ext/Config/Config_xs.in"
+#line 197 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str695,		T_BOO,	0,"@@d_PRIeldbl@@"},
       {-1, -1, 0, NULL},
-#line 209 "ext/Config/Config_xs.in"
+#line 217 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str697,		T_BOO,	0,"@@d_atoll@@"},
       {-1, -1, 0, NULL},
-#line 638 "ext/Config/Config_xs.in"
+#line 646 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str699,		T_BOO,	0,"@@d_strlcat@@"},
-#line 1092 "ext/Config/Config_xs.in"
+#line 1100 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str700,		T_STR,	0,"@@sPRIFUldbl@@"},
       {-1, -1, 0, NULL},
-#line 998 "ext/Config/Config_xs.in"
+#line 1006 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str702,		T_STR,	0,"@@man1dir@@"},
       {-1, -1, 0, NULL},
-#line 400 "ext/Config/Config_xs.in"
+#line 408 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str704,		T_BOO,	0,"@@d_int64_t@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1001 "ext/Config/Config_xs.in"
+#line 1009 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str707,		T_STR,	0,"@@man3dir@@"},
-#line 194 "ext/Config/Config_xs.in"
+#line 202 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str708,		T_BOO,	0,"@@d_PRIu64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 88 "ext/Config/Config_xs.in"
+#line 96 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str716,			T_EMP,	0,"@@Source@@"},
-#line 201 "ext/Config/Config_xs.in"
+#line 209 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str717,		T_BOO,	0,"@@d_aintl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1142 "ext/Config/Config_xs.in"
+#line 1150 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str722,		T_STR,	0,"@@sitelib_stem@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 142 "ext/Config/Config_xs.in"
+#line 150 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str728,		T_STR,	0,"@@compress@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1043 "ext/Config/Config_xs.in"
+#line 1051 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str731,			T_STR,	0,"@@osname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 632 "ext/Config/Config_xs.in"
+#line 640 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str734,		T_BOO,	0,"@@d_strcoll@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 266 "ext/Config/Config_xs.in"
+#line 274 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str741,			T_BOO,	0,"@@d_dup2@@"},
       {-1, -1, 0, NULL},
-#line 1225 "ext/Config/Config_xs.in"
+#line 1233 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str743,		T_BOO,	0,"@@usecperl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1249 "ext/Config/Config_xs.in"
+#line 1257 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str753,		T_BOO,	0,"@@usesocks@@"},
       {-1, -1, 0, NULL},
-#line 578 "ext/Config/Config_xs.in"
+#line 586 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str755,	T_BOO,	0,"@@d_setprotoent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1254 "ext/Config/Config_xs.in"
+#line 1262 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str776,			T_STR,	0,"@@usrinc@@"},
-#line 666 "ext/Config/Config_xs.in"
+#line 674 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str777,		T_BOO,	0,"@@d_tm_tm_zone@@"},
-#line 546 "ext/Config/Config_xs.in"
+#line 554 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str778,		T_BOO,	0,"@@d_scalbn@@"},
       {-1, -1, 0, NULL},
-#line 544 "ext/Config/Config_xs.in"
+#line 552 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str780,		T_BOO,	0,"@@d_sanemcmp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 726 "ext/Config/Config_xs.in"
+#line 734 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str785,			T_STR,	0,"@@emacs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1245 "ext/Config/Config_xs.in"
+#line 1253 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str807,		T_BOO,	0,"@@usereentrant@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 922 "ext/Config/Config_xs.in"
+#line 930 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str818,		T_STR,	0,"@@installscript@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1221 "ext/Config/Config_xs.in"
+#line 1229 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str834,		T_BOO,	0,"@@use5005threads@@"},
-#line 181 "ext/Config/Config_xs.in"
+#line 189 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str835,	T_INT,	0,"@@ctermid_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 240 "ext/Config/Config_xs.in"
+#line 248 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str837,		T_BOO,	0,"@@d_const@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 275 "ext/Config/Config_xs.in"
+#line 283 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str855,	T_BOO,	0,"@@d_endprotoent_r@@"},
-#line 175 "ext/Config/Config_xs.in"
+#line 183 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str856,			T_STR,	0,"@@cpprun@@"},
       {-1, -1, 0, NULL},
-#line 644 "ext/Config/Config_xs.in"
+#line 652 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str858,		T_BOO,	0,"@@d_strtoq@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1177 "ext/Config/Config_xs.in"
+#line 1185 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str874,		T_STR,	0,"@@stdio_ptr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 839 "ext/Config/Config_xs.in"
+#line 847 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str908,		T_BOO,	0,"@@i_locale@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 838 "ext/Config/Config_xs.in"
+#line 846 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str918,		T_BOO,	0,"@@i_limits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 849 "ext/Config/Config_xs.in"
+#line 857 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str922,		T_BOO,	0,"@@i_netinettcp@@"},
       {-1, -1, 0, NULL},
-#line 645 "ext/Config/Config_xs.in"
+#line 653 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str924,		T_BOO,	0,"@@d_strtoul@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1239 "ext/Config/Config_xs.in"
+#line 1247 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str935,			T_STR,	0,"@@usenm@@"},
-#line 550 "ext/Config/Config_xs.in"
+#line 558 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str936,		T_BOO,	0,"@@d_seekdir@@"},
       {-1, -1, 0, NULL},
-#line 841 "ext/Config/Config_xs.in"
+#line 849 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str938,		T_BOO,	0,"@@i_malloc@@"},
-#line 1242 "ext/Config/Config_xs.in"
+#line 1250 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str939,		T_BOO,	0,"@@useperlio@@"},
-#line 281 "ext/Config/Config_xs.in"
+#line 289 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str940,			T_BOO,	0,"@@d_erf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 996 "ext/Config/Config_xs.in"
+#line 1004 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str944,		T_STR,	0,"@@mallocsrc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 257 "ext/Config/Config_xs.in"
+#line 265 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str957,		T_BOO,	0,"@@d_dirfd@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 173 "ext/Config/Config_xs.in"
+#line 181 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str962,		T_STR,	0,"@@cpplast@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 646 "ext/Config/Config_xs.in"
+#line 654 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str965,		T_BOO,	0,"@@d_strtoull@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 469 "ext/Config/Config_xs.in"
+#line 477 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str975,		T_BOO,	0,"@@d_mprotect@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 828 "ext/Config/Config_xs.in"
+#line 836 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str984,			T_BOO,	0,"@@i_fp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 949 "ext/Config/Config_xs.in"
+#line 957 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1008,		T_BOO,	0,"@@ld_can_script@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 444 "ext/Config/Config_xs.in"
+#line 452 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1014,		T_BOO,	0,"@@d_lroundl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 899 "ext/Config/Config_xs.in"
+#line 907 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1023,		T_BOO,	0,"@@i_unistd@@"},
       {-1, -1, 0, NULL},
-#line 1150 "ext/Config/Config_xs.in"
+#line 1158 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1025,		T_STR,	0,"@@sitescript@@"},
-#line 465 "ext/Config/Config_xs.in"
+#line 473 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1026,			T_BOO,	0,"@@d_mmap@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 318 "ext/Config/Config_xs.in"
+#line 326 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1033,		T_BOO,	0,"@@d_fseeko@@"},
-#line 741 "ext/Config/Config_xs.in"
+#line 749 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1034,			T_STR,	0,"@@find@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 453 "ext/Config/Config_xs.in"
+#line 461 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1038,		T_BOO,	0,"@@d_memchr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1290 "ext/Config/Config_xs.in"
+#line 1298 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1043,			T_STR,	0,"@@zip@@"},
       {-1, -1, 0, NULL},
-#line 1086 "ext/Config/Config_xs.in"
+#line 1094 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1045,			T_STR,	0,"@@runnm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1048 "ext/Config/Config_xs.in"
+#line 1056 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1052,		T_STR,	0,"@@passcat@@"},
-#line 1152 "ext/Config/Config_xs.in"
+#line 1160 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1053,		T_INT,	0,"@@sizesize@@"},
-#line 141 "ext/Config/Config_xs.in"
+#line 149 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1054,			T_STR,	0,"@@comm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 675 "ext/Config/Config_xs.in"
+#line 683 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1067,		T_BOO,	0,"@@d_umask@@"},
-#line 744 "ext/Config/Config_xs.in"
+#line 752 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1068,		T_INT,	0,"@@fpossize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 813 "ext/Config/Config_xs.in"
+#line 821 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1071,			T_INT,	0,"@@i8size@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 399 "ext/Config/Config_xs.in"
+#line 407 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1075,		T_BOO,	0,"@@d_inetpton@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 426 "ext/Config/Config_xs.in"
+#line 434 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1078,			T_BOO,	0,"@@d_link@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 682 "ext/Config/Config_xs.in"
+#line 690 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1082,		T_BOO,	0,"@@d_ustat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 900 "ext/Config/Config_xs.in"
+#line 908 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1087,		T_BOO,	0,"@@i_ustat@@"},
-#line 93 "ext/Config/Config_xs.in"
+#line 101 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1088,			T_STR,	0,"@@afs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 127 "ext/Config/Config_xs.in"
+#line 135 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1106,			T_STR,	0,"@@ccname@@"},
       {-1, -1, 0, NULL},
-#line 553 "ext/Config/Config_xs.in"
+#line 561 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1108,		T_BOO,	0,"@@d_semctl@@"},
       {-1, -1, 0, NULL},
-#line 1218 "ext/Config/Config_xs.in"
+#line 1226 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1110,			T_STR,	0,"@@uname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1024 "ext/Config/Config_xs.in"
+#line 1032 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1114,		T_STR,	0,"@@nm_so_opt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 639 "ext/Config/Config_xs.in"
+#line 647 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1119,		T_BOO,	0,"@@d_strlcpy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 525 "ext/Config/Config_xs.in"
+#line 533 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1125,		T_BOO,	0,"@@d_random_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 282 "ext/Config/Config_xs.in"
+#line 290 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1156,			T_BOO,	0,"@@d_erfc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 625 "ext/Config/Config_xs.in"
+#line 633 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1166,	T_BOO,	0,"@@d_stdio_ptr_lval@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 547 "ext/Config/Config_xs.in"
+#line 555 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1169,		T_BOO,	0,"@@d_scalbnl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 454 "ext/Config/Config_xs.in"
+#line 462 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1173,		T_BOO,	0,"@@d_memcmp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 74 "ext/Config/Config_xs.in"
+#line 82 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1178,			T_EMP,	0,"@@Locker@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 261 "ext/Config/Config_xs.in"
+#line 269 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1188,		T_BOO,	0,"@@d_dlopen@@"},
       {-1, -1, 0, NULL},
-#line 627 "ext/Config/Config_xs.in"
+#line 635 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1190,	T_BOO,	0,"@@d_stdio_ptr_lval_sets_cnt@@"},
       {-1, -1, 0, NULL},
-#line 613 "ext/Config/Config_xs.in"
+#line 621 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1192,		T_BOO,	0,"@@d_sqrtl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 669 "ext/Config/Config_xs.in"
+#line 677 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1200,		T_BOO,	0,"@@d_truncate@@"},
-#line 1157 "ext/Config/Config_xs.in"
+#line 1165 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1201,		T_STR,	0,"@@sockethdr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 859 "ext/Config/Config_xs.in"
+#line 867 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1209,		T_BOO,	0,"@@i_socks@@"},
       {-1, -1, 0, NULL},
-#line 286 "ext/Config/Config_xs.in"
+#line 294 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1211,		T_BOO,	0,"@@d_faststdio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 402 "ext/Config/Config_xs.in"
+#line 410 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1221,	T_BOO,	0,"@@d_ip_mreq_source@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 557 "ext/Config/Config_xs.in"
+#line 565 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1232,		T_BOO,	0,"@@d_semop@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1226 "ext/Config/Config_xs.in"
+#line 1234 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1240,	T_BOO,	0,"@@usecrosscompile@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 674 "ext/Config/Config_xs.in"
+#line 682 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1243,		T_BOO,	0,"@@d_ualarm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 507 "ext/Config/Config_xs.in"
+#line 515 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1246,	T_BOO,	0,"@@d_prctl_set_name@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 823 "ext/Config/Config_xs.in"
+#line 831 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1257,		T_BOO,	0,"@@i_dlfcn@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 301 "ext/Config/Config_xs.in"
+#line 309 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1287,		T_BOO,	0,"@@d_flock@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1010 "ext/Config/Config_xs.in"
+#line 1018 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1294,		T_BOO,	0,"@@multiarch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 626 "ext/Config/Config_xs.in"
+#line 634 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1299,	T_BOO,	0,"@@d_stdio_ptr_lval_nochange_cnt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1006 "ext/Config/Config_xs.in"
+#line 1014 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1312,			T_STR,	0,"@@mkdir@@"},
       {-1, -1, 0, NULL},
-#line 1219 "ext/Config/Config_xs.in"
+#line 1227 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1314,			T_STR,	0,"@@uniq@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1005 "ext/Config/Config_xs.in"
+#line 1013 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1325,		T_STR,	0,"@@mistrustnm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 458 "ext/Config/Config_xs.in"
+#line 466 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1329,		T_BOO,	0,"@@d_mkdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 294 "ext/Config/Config_xs.in"
+#line 302 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1341,			T_BOO,	0,"@@d_fdim@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 256 "ext/Config/Config_xs.in"
+#line 264 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1351,		T_BOO,	0,"@@d_dir_dd_fd@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 842 "ext/Config/Config_xs.in"
+#line 850 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1359,		T_BOO,	0,"@@i_mallocmalloc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 747 "ext/Config/Config_xs.in"
+#line 755 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1364,			T_STR,	0,"@@from@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1289 "ext/Config/Config_xs.in"
+#line 1297 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1389,			T_STR,	0,"@@zcat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 280 "ext/Config/Config_xs.in"
+#line 288 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1394,		T_BOO,	0,"@@d_eofnblk@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 524 "ext/Config/Config_xs.in"
+#line 532 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1401,			T_BOO,	0,"@@d_quad@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 672 "ext/Config/Config_xs.in"
+#line 680 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1408,		T_BOO,	0,"@@d_tzname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 976 "ext/Config/Config_xs.in"
+#line 984 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1429,		T_STR,	0,"@@locincpth@@"},
-#line 91 "ext/Config/Config_xs.in"
+#line 99 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1430,			T_STR,	0,"@@_exe@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 323 "ext/Config/Config_xs.in"
+#line 331 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1433,		T_BOO,	0,"@@d_ftello@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 463 "ext/Config/Config_xs.in"
+#line 471 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1440,		T_BOO,	0,"@@d_mktime@@"},
-#line 305 "ext/Config/Config_xs.in"
+#line 313 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1441,			T_BOO,	0,"@@d_fmin@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 302 "ext/Config/Config_xs.in"
+#line 310 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1457,		T_BOO,	0,"@@d_flockproto@@"},
-#line 680 "ext/Config/Config_xs.in"
+#line 688 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1458,		T_BOO,	0,"@@d_usleep@@"},
-#line 526 "ext/Config/Config_xs.in"
+#line 534 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1459,		T_BOO,	0,"@@d_re_comp@@"},
-#line 407 "ext/Config/Config_xs.in"
+#line 415 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1460,		T_BOO,	0,"@@d_isfinite@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 735 "ext/Config/Config_xs.in"
+#line 743 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1465,			T_STR,	0,"@@expr@@"},
-#line 992 "ext/Config/Config_xs.in"
+#line 1000 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1466,			T_STR,	0,"@@make@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 711 "ext/Config/Config_xs.in"
+#line 719 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1471,			T_STR,	0,"@@dlext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 96 "ext/Config/Config_xs.in"
+#line 104 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1485,		T_STR,	0,"@@ansi2knr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 587 "ext/Config/Config_xs.in"
+#line 595 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1489,		T_BOO,	0,"@@d_setsent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1212 "ext/Config/Config_xs.in"
+#line 1220 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1496,			T_INT,	0,"@@u8size@@"},
       {-1, -1, 0, NULL},
-#line 298 "ext/Config/Config_xs.in"
+#line 306 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1498,		T_BOO,	0,"@@d_finite@@"},
       {-1, -1, 0, NULL},
-#line 303 "ext/Config/Config_xs.in"
+#line 311 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1500,			T_BOO,	0,"@@d_fma@@"},
-#line 408 "ext/Config/Config_xs.in"
+#line 416 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1501,		T_BOO,	0,"@@d_isfinitel@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 637 "ext/Config/Config_xs.in"
+#line 645 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1505,		T_BOO,	0,"@@d_strftime@@"},
       {-1, -1, 0, NULL},
-#line 912 "ext/Config/Config_xs.in"
+#line 920 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1507,	T_STR,	0,"@@initialinstalllocation@@"},
       {-1, -1, 0, NULL},
-#line 325 "ext/Config/Config_xs.in"
+#line 333 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1509,		T_BOO,	0,"@@d_futimes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1062 "ext/Config/Config_xs.in"
+#line 1070 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1512,			T_STR,	0,"@@pmake@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 495 "ext/Config/Config_xs.in"
+#line 503 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1524,	T_BOO,	0,"@@d_old_pthread_create_joinable@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1102 "ext/Config/Config_xs.in"
+#line 1110 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1533,		T_STR,	0,"@@sPRIx64@@"},
-#line 572 "ext/Config/Config_xs.in"
+#line 580 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1534,		T_BOO,	0,"@@d_setpent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1255 "ext/Config/Config_xs.in"
+#line 1263 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1546,			T_STR,	0,"@@uuname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 182 "ext/Config/Config_xs.in"
+#line 190 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1553,		T_INT,	0,"@@ctime_r_proto@@"},
-#line 267 "ext/Config/Config_xs.in"
+#line 275 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1554,		T_BOO,	0,"@@d_eaccess@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1169 "ext/Config/Config_xs.in"
+#line 1177 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1559,		T_STR,	0,"@@startperl@@"},
       {-1, -1, 0, NULL},
-#line 579 "ext/Config/Config_xs.in"
+#line 587 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1561,		T_BOO,	0,"@@d_setpwent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 530 "ext/Config/Config_xs.in"
+#line 538 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1567,		T_BOO,	0,"@@d_readlink@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1054 "ext/Config/Config_xs.in"
+#line 1062 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1573,	T_STR,	0,"@@perl_static_inline@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 250 "ext/Config/Config_xs.in"
+#line 258 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1579,		T_BOO,	0,"@@d_ctime_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 580 "ext/Config/Config_xs.in"
+#line 588 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1583,		T_BOO,	0,"@@d_setpwent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 278 "ext/Config/Config_xs.in"
+#line 286 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1589,		T_BOO,	0,"@@d_endsent@@"},
-#line 196 "ext/Config/Config_xs.in"
+#line 204 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1590,		T_BOO,	0,"@@d_SCNfldbl@@"},
       {-1, -1, 0, NULL},
-#line 500 "ext/Config/Config_xs.in"
+#line 508 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1592,		T_BOO,	0,"@@d_pause@@"},
       {-1, -1, 0, NULL},
-#line 570 "ext/Config/Config_xs.in"
+#line 578 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1594,		T_BOO,	0,"@@d_setnent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1075 "ext/Config/Config_xs.in"
+#line 1083 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1599,		T_INT,	0,"@@random_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 190 "ext/Config/Config_xs.in"
+#line 198 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1605,		T_BOO,	0,"@@d_PRIfldbl@@"},
       {-1, -1, 0, NULL},
-#line 738 "ext/Config/Config_xs.in"
+#line 746 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1607,			T_STR,	0,"@@extras@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 295 "ext/Config/Config_xs.in"
+#line 303 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1620,		T_BOO,	0,"@@d_fds_bits@@"},
       {-1, -1, 0, NULL},
-#line 748 "ext/Config/Config_xs.in"
+#line 756 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1622,		T_STR,	0,"@@full_ar@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1108 "ext/Config/Config_xs.in"
+#line 1116 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1628,		T_STR,	0,"@@seedfunc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 274 "ext/Config/Config_xs.in"
+#line 282 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1634,		T_BOO,	0,"@@d_endpent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 94 "ext/Config/Config_xs.in"
+#line 102 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1642,		T_STR,	0,"@@afsroot@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 315 "ext/Config/Config_xs.in"
+#line 323 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1645,		T_BOO,	0,"@@d_fpos64_t@@"},
-#line 243 "ext/Config/Config_xs.in"
+#line 251 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1646,		T_BOO,	0,"@@d_cplusplus@@"},
-#line 827 "ext/Config/Config_xs.in"
+#line 835 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1647,		T_BOO,	0,"@@i_float@@"},
-#line 677 "ext/Config/Config_xs.in"
+#line 685 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1648,		T_BOO,	0,"@@d_union_semun@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1058 "ext/Config/Config_xs.in"
+#line 1066 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1652,			T_STR,	0,"@@pg@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 290 "ext/Config/Config_xs.in"
+#line 298 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1657,		T_BOO,	0,"@@d_fcntl@@"},
       {-1, -1, 0, NULL},
-#line 791 "ext/Config/Config_xs.in"
+#line 799 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1659,			T_STR,	0,"@@grep@@"},
-#line 725 "ext/Config/Config_xs.in"
+#line 733 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1660,			T_STR,	0,"@@egrep@@"},
-#line 276 "ext/Config/Config_xs.in"
+#line 284 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1661,		T_BOO,	0,"@@d_endpwent@@"},
-#line 825 "ext/Config/Config_xs.in"
+#line 833 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1662,		T_BOO,	0,"@@i_fcntl@@"},
-#line 75 "ext/Config/Config_xs.in"
+#line 83 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1663,			T_EMP,	0,"@@Log@@"},
-#line 249 "ext/Config/Config_xs.in"
+#line 257 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1664,		T_BOO,	0,"@@d_ctime64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 609 "ext/Config/Config_xs.in"
+#line 617 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1668,		T_BOO,	0,"@@d_socklen_t@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 464 "ext/Config/Config_xs.in"
+#line 472 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1672,		T_BOO,	0,"@@d_mktime64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 277 "ext/Config/Config_xs.in"
+#line 285 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1683,		T_BOO,	0,"@@d_endpwent_r@@"},
-#line 195 "ext/Config/Config_xs.in"
+#line 203 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1684,		T_BOO,	0,"@@d_PRIx64@@"},
-#line 833 "ext/Config/Config_xs.in"
+#line 841 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1685,			T_BOO,	0,"@@i_grp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1131 "ext/Config/Config_xs.in"
+#line 1139 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1688,		T_INT,	0,"@@sig_size@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 834 "ext/Config/Config_xs.in"
+#line 842 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1693,		T_BOO,	0,"@@i_ieeefp@@"},
-#line 272 "ext/Config/Config_xs.in"
+#line 280 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1694,		T_BOO,	0,"@@d_endnent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 563 "ext/Config/Config_xs.in"
+#line 571 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1699,		T_BOO,	0,"@@d_setgrps@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 561 "ext/Config/Config_xs.in"
+#line 569 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1710,		T_BOO,	0,"@@d_setgrent@@"},
       {-1, -1, 0, NULL},
-#line 284 "ext/Config/Config_xs.in"
+#line 292 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1712,			T_BOO,	0,"@@d_exp2@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1040 "ext/Config/Config_xs.in"
+#line 1048 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1717,	T_STR,	0,"@@old_pthread_create_joinable@@"},
-#line 865 "ext/Config/Config_xs.in"
+#line 873 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1718,		T_BOO,	0,"@@i_string@@"},
-#line 1241 "ext/Config/Config_xs.in"
+#line 1249 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1719,		T_STR,	0,"@@useopcode@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 457 "ext/Config/Config_xs.in"
+#line 465 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1728,		T_BOO,	0,"@@d_memset@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 562 "ext/Config/Config_xs.in"
+#line 570 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1732,		T_BOO,	0,"@@d_setgrent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1087 "ext/Config/Config_xs.in"
+#line 1095 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1747,		T_INT,	0,"@@sGMTIME_max@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 366 "ext/Config/Config_xs.in"
+#line 374 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1750,		T_BOO,	0,"@@d_getprior@@"},
       {-1, -1, 0, NULL},
-#line 1180 "ext/Config/Config_xs.in"
+#line 1188 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1752,		T_STR,	0,"@@strings@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 409 "ext/Config/Config_xs.in"
+#line 417 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1757,		T_BOO,	0,"@@d_isinf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1106 "ext/Config/Config_xs.in"
+#line 1114 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1763,		T_STR,	0,"@@scriptdirexp@@"},
       {-1, -1, 0, NULL},
-#line 611 "ext/Config/Config_xs.in"
+#line 619 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1765,		T_BOO,	0,"@@d_socks5_init@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 319 "ext/Config/Config_xs.in"
+#line 327 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1774,		T_BOO,	0,"@@d_fsetpos@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 466 "ext/Config/Config_xs.in"
+#line 474 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1777,		T_BOO,	0,"@@d_modfl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1116 "ext/Config/Config_xs.in"
+#line 1124 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1784,	T_INT,	0,"@@setprotoent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 901 "ext/Config/Config_xs.in"
+#line 909 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1787,		T_BOO,	0,"@@i_utime@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 307 "ext/Config/Config_xs.in"
+#line 315 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1790,		T_BOO,	0,"@@d_fp_class@@"},
       {-1, -1, 0, NULL},
-#line 1115 "ext/Config/Config_xs.in"
+#line 1123 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1792,	T_INT,	0,"@@setnetent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 829 "ext/Config/Config_xs.in"
+#line 837 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1795,		T_BOO,	0,"@@i_fp_class@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 410 "ext/Config/Config_xs.in"
+#line 418 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1798,		T_BOO,	0,"@@d_isinfl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1158 "ext/Config/Config_xs.in"
+#line 1166 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1801,		T_STR,	0,"@@socketlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 268 "ext/Config/Config_xs.in"
+#line 276 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1810,		T_BOO,	0,"@@d_endgrent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1188 "ext/Config/Config_xs.in"
+#line 1196 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1824,		T_STR,	0,"@@targetdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 860 "ext/Config/Config_xs.in"
+#line 868 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1828,		T_BOO,	0,"@@i_stdarg@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 309 "ext/Config/Config_xs.in"
+#line 317 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1831,		T_BOO,	0,"@@d_fp_classl@@"},
-#line 269 "ext/Config/Config_xs.in"
+#line 277 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1832,		T_BOO,	0,"@@d_endgrent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1047 "ext/Config/Config_xs.in"
+#line 1055 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1835,			T_STR,	0,"@@pager@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 984 "ext/Config/Config_xs.in"
+#line 992 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1863,		T_INT,	0,"@@longsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 862 "ext/Config/Config_xs.in"
+#line 870 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1873,		T_BOO,	0,"@@i_stddef@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 85 "ext/Config/Config_xs.in"
+#line 93 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1877,		T_EMP,	0,"@@RCSfile@@"},
-#line 293 "ext/Config/Config_xs.in"
+#line 301 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1878,		T_BOO,	0,"@@d_fd_set@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 730 "ext/Config/Config_xs.in"
+#line 738 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1884,	T_INT,	0,"@@endprotoent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 299 "ext/Config/Config_xs.in"
+#line 307 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1889,		T_BOO,	0,"@@d_finitel@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 729 "ext/Config/Config_xs.in"
+#line 737 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1892,	T_INT,	0,"@@endnetent_r_proto@@"},
-#line 306 "ext/Config/Config_xs.in"
+#line 314 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1893,			T_BOO,	0,"@@d_fork@@"},
       {-1, -1, 0, NULL},
-#line 1204 "ext/Config/Config_xs.in"
+#line 1212 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1895,			T_STR,	0,"@@troff@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1190 "ext/Config/Config_xs.in"
+#line 1198 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1900,		T_STR,	0,"@@targethost@@"},
       {-1, -1, 0, NULL},
-#line 554 "ext/Config/Config_xs.in"
+#line 562 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1902,	T_BOO,	0,"@@d_semctl_semid_ds@@"},
       {-1, -1, 0, NULL},
-#line 737 "ext/Config/Config_xs.in"
+#line 745 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1904,		T_STR,	0,"@@extern_C@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1119 "ext/Config/Config_xs.in"
+#line 1127 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1907,			T_STR,	0,"@@sh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 208 "ext/Config/Config_xs.in"
+#line 216 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1912,		T_BOO,	0,"@@d_atolf@@"},
-#line 1074 "ext/Config/Config_xs.in"
+#line 1082 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1913,		T_STR,	0,"@@randfunc@@"},
       {-1, -1, 0, NULL},
-#line 108 "ext/Config/Config_xs.in"
+#line 116 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1915,	T_INT,	0,"@@asctime_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 854 "ext/Config/Config_xs.in"
+#line 862 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1922,			T_BOO,	0,"@@i_pwd@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 589 "ext/Config/Config_xs.in"
+#line 597 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1925,		T_BOO,	0,"@@d_setsid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 612 "ext/Config/Config_xs.in"
+#line 620 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1929,	T_BOO,	0,"@@d_sprintf_returns_strlen@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 415 "ext/Config/Config_xs.in"
+#line 423 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1946,			T_BOO,	0,"@@d_j0@@"},
-#line 468 "ext/Config/Config_xs.in"
+#line 476 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1947,		T_BOO,	0,"@@d_modflproto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 393 "ext/Config/Config_xs.in"
+#line 401 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1952,		T_BOO,	0,"@@d_ilogb@@"},
       {-1, -1, 0, NULL},
-#line 559 "ext/Config/Config_xs.in"
+#line 567 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1954,		T_BOO,	0,"@@d_setegid@@"},
       {-1, -1, 0, NULL},
-#line 437 "ext/Config/Config_xs.in"
+#line 445 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1956,			T_BOO,	0,"@@d_log2@@"},
-#line 221 "ext/Config/Config_xs.in"
+#line 229 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1957,			T_BOO,	0,"@@d_bsd@@"},
       {-1, -1, 0, NULL},
-#line 585 "ext/Config/Config_xs.in"
+#line 593 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1959,		T_BOO,	0,"@@d_setrgid@@"},
       {-1, -1, 0, NULL},
-#line 820 "ext/Config/Config_xs.in"
+#line 828 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1961,			T_BOO,	0,"@@i_db@@"},
-#line 911 "ext/Config/Config_xs.in"
+#line 919 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1962,			T_STR,	0,"@@inews@@"},
-#line 538 "ext/Config/Config_xs.in"
+#line 546 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1963,		T_BOO,	0,"@@d_rewinddir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1070 "ext/Config/Config_xs.in"
+#line 1078 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1972,		T_INT,	0,"@@ptrsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 807 "ext/Config/Config_xs.in"
+#line 815 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1977,		T_INT,	0,"@@i16size@@"},
       {-1, -1, 0, NULL},
-#line 1199 "ext/Config/Config_xs.in"
+#line 1207 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1979,		T_INT,	0,"@@tmpnam_r_proto@@"},
-#line 1194 "ext/Config/Config_xs.in"
+#line 1202 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1980,			T_STR,	0,"@@tbl@@"},
-#line 961 "ext/Config/Config_xs.in"
+#line 969 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1981,			T_STR,	0,"@@libs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 416 "ext/Config/Config_xs.in"
+#line 424 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1987,			T_BOO,	0,"@@d_j0l@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1026 "ext/Config/Config_xs.in"
+#line 1034 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1990,			T_STR,	0,"@@nroff@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 394 "ext/Config/Config_xs.in"
+#line 402 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1993,		T_BOO,	0,"@@d_ilogbl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 573 "ext/Config/Config_xs.in"
+#line 581 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str1999,		T_BOO,	0,"@@d_setpgid@@"},
-#line 963 "ext/Config/Config_xs.in"
+#line 971 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2000,		T_STR,	0,"@@libsdirs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 533 "ext/Config/Config_xs.in"
+#line 541 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2003,		T_BOO,	0,"@@d_regcmp@@"},
-#line 1285 "ext/Config/Config_xs.in"
+#line 1293 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2004,			T_STR,	0,"@@vi@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 778 "ext/Config/Config_xs.in"
+#line 786 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2017,		T_STR,	0,"@@git_ancestor@@"},
       {-1, -1, 0, NULL},
-#line 1135 "ext/Config/Config_xs.in"
+#line 1143 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2019,		T_STR,	0,"@@sitebin@@"},
-#line 470 "ext/Config/Config_xs.in"
+#line 478 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2020,			T_BOO,	0,"@@d_msg@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1127 "ext/Config/Config_xs.in"
+#line 1135 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2023,		T_STR,	0,"@@sig_name@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 991 "ext/Config/Config_xs.in"
+#line 999 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2031,			T_STR,	0,"@@mailx@@"},
-#line 811 "ext/Config/Config_xs.in"
+#line 819 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2032,		T_INT,	0,"@@i64size@@"},
       {-1, -1, 0, NULL},
-#line 798 "ext/Config/Config_xs.in"
+#line 806 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2034,			T_STR,	0,"@@hint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 941 "ext/Config/Config_xs.in"
+#line 949 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2037,		T_INT,	0,"@@intsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 560 "ext/Config/Config_xs.in"
+#line 568 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2041,		T_BOO,	0,"@@d_seteuid@@"},
-#line 676 "ext/Config/Config_xs.in"
+#line 684 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2042,		T_BOO,	0,"@@d_uname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 112 "ext/Config/Config_xs.in"
+#line 120 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2045,			T_STR,	0,"@@bin@@"},
-#line 586 "ext/Config/Config_xs.in"
+#line 594 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2046,		T_BOO,	0,"@@d_setruid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 531 "ext/Config/Config_xs.in"
+#line 539 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2054,		T_BOO,	0,"@@d_readv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1044 "ext/Config/Config_xs.in"
+#line 1052 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2058,			T_STR,	0,"@@osvers@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 802 "ext/Config/Config_xs.in"
+#line 810 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2063,		T_STR,	0,"@@hostperl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 184 "ext/Config/Config_xs.in"
+#line 192 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2068,		T_BOO,	0,"@@d_PRIEUldbl@@"},
-#line 113 "ext/Config/Config_xs.in"
+#line 121 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2069,		T_BOO,	0,"@@bin_ELF@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 186 "ext/Config/Config_xs.in"
+#line 194 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2073,		T_BOO,	0,"@@d_PRIGUldbl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 722 "ext/Config/Config_xs.in"
+#line 730 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2076,			T_STR,	0,"@@eagain@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 480 "ext/Config/Config_xs.in"
+#line 488 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2083,		T_BOO,	0,"@@d_msgsnd@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1120 "ext/Config/Config_xs.in"
+#line 1128 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2089,			T_STR,	0,"@@shar@@"},
-#line 1145 "ext/Config/Config_xs.in"
+#line 1153 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2090,		T_STR,	0,"@@siteman1direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 185 "ext/Config/Config_xs.in"
+#line 193 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2093,		T_BOO,	0,"@@d_PRIFUldbl@@"},
-#line 1061 "ext/Config/Config_xs.in"
+#line 1069 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2094,		T_STR,	0,"@@plibpth@@"},
-#line 1147 "ext/Config/Config_xs.in"
+#line 1155 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2095,		T_STR,	0,"@@siteman3direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 348 "ext/Config/Config_xs.in"
+#line 356 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2098,		T_BOO,	0,"@@d_getmnt@@"},
       {-1, -1, 0, NULL},
-#line 1118 "ext/Config/Config_xs.in"
+#line 1126 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2100,	T_INT,	0,"@@setservent_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 115 "ext/Config/Config_xs.in"
+#line 123 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2102,			T_STR,	0,"@@bison@@"},
-#line 285 "ext/Config/Config_xs.in"
+#line 293 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2103,		T_BOO,	0,"@@d_expm1@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 616 "ext/Config/Config_xs.in"
+#line 624 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2107,		T_BOO,	0,"@@d_sresgproto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 835 "ext/Config/Config_xs.in"
+#line 843 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2110,		T_BOO,	0,"@@i_inttypes@@"},
-#line 405 "ext/Config/Config_xs.in"
+#line 413 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2111,		T_BOO,	0,"@@d_isascii@@"},
       {-1, -1, 0, NULL},
-#line 571 "ext/Config/Config_xs.in"
+#line 579 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2113,		T_BOO,	0,"@@d_setnetent_r@@"},
       {-1, -1, 0, NULL},
-#line 608 "ext/Config/Config_xs.in"
+#line 616 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2115,		T_BOO,	0,"@@d_socket@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1133 "ext/Config/Config_xs.in"
+#line 1141 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2118,		T_STR,	0,"@@sitearch@@"},
-#line 695 "ext/Config/Config_xs.in"
+#line 703 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2119,		T_BOO,	0,"@@d_wait4@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 180 "ext/Config/Config_xs.in"
+#line 188 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2123,			T_STR,	0,"@@csh@@"},
-#line 1282 "ext/Config/Config_xs.in"
+#line 1290 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2124,		T_STR,	0,"@@version@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1215 "ext/Config/Config_xs.in"
+#line 1223 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2127,		T_INT,	0,"@@uidsign@@"},
       {-1, -1, 0, NULL},
-#line 1069 "ext/Config/Config_xs.in"
+#line 1077 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2129,		T_BOO,	0,"@@prototype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1214 "ext/Config/Config_xs.in"
+#line 1222 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2144,		T_STR,	0,"@@uidformat@@"},
-#line 246 "ext/Config/Config_xs.in"
+#line 254 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2145,			T_BOO,	0,"@@d_csh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 558 "ext/Config/Config_xs.in"
+#line 566 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2149,		T_BOO,	0,"@@d_sendmsg@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 809 "ext/Config/Config_xs.in"
+#line 817 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2167,		T_INT,	0,"@@i32size@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 86 "ext/Config/Config_xs.in"
+#line 94 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2170,		T_EMP,	0,"@@Revision@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1081 "ext/Config/Config_xs.in"
+#line 1089 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2175,		T_INT,	0,"@@revision@@"},
       {-1, -1, 0, NULL},
-#line 1139 "ext/Config/Config_xs.in"
+#line 1147 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2177,		T_STR,	0,"@@sitehtml3dir@@"},
       {-1, -1, 0, NULL},
-#line 724 "ext/Config/Config_xs.in"
+#line 732 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2179,			T_STR,	0,"@@echo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 231 "ext/Config/Config_xs.in"
+#line 239 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2183,			T_BOO,	0,"@@d_cbrt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 617 "ext/Config/Config_xs.in"
+#line 625 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2194,		T_BOO,	0,"@@d_sresuproto@@"},
-#line 621 "ext/Config/Config_xs.in"
+#line 629 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2195,		T_BOO,	0,"@@d_statfs_s@@"},
-#line 957 "ext/Config/Config_xs.in"
+#line 965 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2196,			T_STR,	0,"@@libc@@"},
       {-1, -1, 0, NULL},
-#line 235 "ext/Config/Config_xs.in"
+#line 243 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2198,		T_BOO,	0,"@@d_chsize@@"},
       {-1, -1, 0, NULL},
-#line 732 "ext/Config/Config_xs.in"
+#line 740 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2200,	T_INT,	0,"@@endservent_r_proto@@"},
-#line 1112 "ext/Config/Config_xs.in"
+#line 1120 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2201,	T_INT,	0,"@@setgrent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 345 "ext/Config/Config_xs.in"
+#line 353 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2211,		T_BOO,	0,"@@d_getitimer@@"},
       {-1, -1, 0, NULL},
-#line 273 "ext/Config/Config_xs.in"
+#line 281 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2213,		T_BOO,	0,"@@d_endnetent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1140 "ext/Config/Config_xs.in"
+#line 1148 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2225,	T_STR,	0,"@@sitehtml3direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 397 "ext/Config/Config_xs.in"
+#line 405 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2242,		T_BOO,	0,"@@d_inetaton@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 324 "ext/Config/Config_xs.in"
+#line 332 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2257,		T_BOO,	0,"@@d_ftime@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 183 "ext/Config/Config_xs.in"
+#line 191 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2262,		T_STR,	0,"@@d_Gconvert@@"},
-#line 234 "ext/Config/Config_xs.in"
+#line 242 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2263,		T_BOO,	0,"@@d_chroot@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 429 "ext/Config/Config_xs.in"
+#line 437 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2266,		T_BOO,	0,"@@d_llround@@"},
       {-1, -1, 0, NULL},
-#line 1077 "ext/Config/Config_xs.in"
+#line 1085 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2268,			T_STR,	0,"@@ranlib@@"},
       {-1, -1, 0, NULL},
-#line 649 "ext/Config/Config_xs.in"
+#line 657 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2270,		T_BOO,	0,"@@d_suidsafe@@"},
-#line 239 "ext/Config/Config_xs.in"
+#line 247 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2271,		T_BOO,	0,"@@d_cmsghdr_s@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1129 "ext/Config/Config_xs.in"
+#line 1137 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2282,		T_STR,	0,"@@sig_num@@"},
       {-1, -1, 0, NULL},
-#line 421 "ext/Config/Config_xs.in"
+#line 429 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2284,		T_BOO,	0,"@@d_ldexpl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 98 "ext/Config/Config_xs.in"
+#line 106 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2294,		T_INT,	0,"@@api_revision@@"},
       {-1, -1, 0, NULL},
-#line 910 "ext/Config/Config_xs.in"
+#line 918 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2296,			T_STR,	0,"@@incpth@@"},
       {-1, -1, 0, NULL},
-#line 449 "ext/Config/Config_xs.in"
+#line 457 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2298,		T_BOO,	0,"@@d_malloc_size@@"},
       {-1, -1, 0, NULL},
-#line 191 "ext/Config/Config_xs.in"
+#line 199 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2300,		T_BOO,	0,"@@d_PRIgldbl@@"},
-#line 727 "ext/Config/Config_xs.in"
+#line 735 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2301,	T_INT,	0,"@@endgrent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 555 "ext/Config/Config_xs.in"
+#line 563 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2304,		T_BOO,	0,"@@d_semctl_semun@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 430 "ext/Config/Config_xs.in"
+#line 438 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2307,		T_BOO,	0,"@@d_llroundl@@"},
-#line 568 "ext/Config/Config_xs.in"
+#line 576 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2308,		T_BOO,	0,"@@d_setlocale@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 176 "ext/Config/Config_xs.in"
+#line 184 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2315,		T_STR,	0,"@@cppstdin@@"},
       {-1, -1, 0, NULL},
-#line 1172 "ext/Config/Config_xs.in"
+#line 1180 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2317,		T_STR,	0,"@@stdchar@@"},
-#line 1132 "ext/Config/Config_xs.in"
+#line 1140 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2318,		T_STR,	0,"@@signal_t@@"},
       {-1, -1, 0, NULL},
-#line 591 "ext/Config/Config_xs.in"
+#line 599 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2320,			T_BOO,	0,"@@d_shm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1066 "ext/Config/Config_xs.in"
+#line 1074 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2324,		T_STR,	0,"@@privlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 569 "ext/Config/Config_xs.in"
+#line 577 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2330,		T_BOO,	0,"@@d_setlocale_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1262 "ext/Config/Config_xs.in"
+#line 1270 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2334,		T_BOO,	0,"@@vaproto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 229 "ext/Config/Config_xs.in"
+#line 237 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2341,		T_BOO,	0,"@@d_casti32@@"},
-#line 1137 "ext/Config/Config_xs.in"
+#line 1145 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2342,		T_STR,	0,"@@sitehtml1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 681 "ext/Config/Config_xs.in"
+#line 689 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2348,		T_BOO,	0,"@@d_usleepproto@@"},
       {-1, -1, 0, NULL},
-#line 1071 "ext/Config/Config_xs.in"
+#line 1079 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2350,		T_INT,	0,"@@quadkind@@"},
       {-1, -1, 0, NULL},
-#line 821 "ext/Config/Config_xs.in"
+#line 829 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2352,			T_BOO,	0,"@@i_dbm@@"},
       {-1, -1, 0, NULL},
-#line 473 "ext/Config/Config_xs.in"
+#line 481 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2354,		T_BOO,	0,"@@d_msg_oob@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 136 "ext/Config/Config_xs.in"
+#line 144 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2358,		T_INT,	0,"@@charsize@@"},
       {-1, -1, 0, NULL},
-#line 369 "ext/Config/Config_xs.in"
+#line 377 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2360,	T_BOO,	0,"@@d_getprotoent_r@@"},
       {-1, -1, 0, NULL},
-#line 1216 "ext/Config/Config_xs.in"
+#line 1224 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2362,		T_INT,	0,"@@uidsize@@"},
-#line 750 "ext/Config/Config_xs.in"
+#line 758 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2363,		T_STR,	0,"@@full_sed@@"},
       {-1, -1, 0, NULL},
-#line 743 "ext/Config/Config_xs.in"
+#line 751 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2365,			T_STR,	0,"@@flex@@"},
-#line 1267 "ext/Config/Config_xs.in"
+#line 1275 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2366,		T_STR,	0,"@@vendorhtml1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 801 "ext/Config/Config_xs.in"
+#line 809 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2370,		T_STR,	0,"@@hostosname@@"},
-#line 1269 "ext/Config/Config_xs.in"
+#line 1277 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2371,		T_STR,	0,"@@vendorhtml3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 896 "ext/Config/Config_xs.in"
+#line 904 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2375,		T_BOO,	0,"@@i_termio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 723 "ext/Config/Config_xs.in"
+#line 731 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2378,			T_BOO,	0,"@@ebcdic@@"},
       {-1, -1, 0, NULL},
-#line 386 "ext/Config/Config_xs.in"
+#line 394 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2380,		T_BOO,	0,"@@d_gmtime64@@"},
-#line 1096 "ext/Config/Config_xs.in"
+#line 1104 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2381,		T_STR,	0,"@@sPRIeldbl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1011 "ext/Config/Config_xs.in"
+#line 1019 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2384,			T_STR,	0,"@@mv@@"},
       {-1, -1, 0, NULL},
-#line 897 "ext/Config/Config_xs.in"
+#line 905 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2386,		T_BOO,	0,"@@i_termios@@"},
-#line 1064 "ext/Config/Config_xs.in"
+#line 1072 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2387,			T_STR,	0,"@@prefix@@"},
       {-1, -1, 0, NULL},
-#line 230 "ext/Config/Config_xs.in"
+#line 238 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2389,		T_BOO,	0,"@@d_castneg@@"},
-#line 1138 "ext/Config/Config_xs.in"
+#line 1146 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2390,	T_STR,	0,"@@sitehtml1direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1109 "ext/Config/Config_xs.in"
+#line 1117 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2395,		T_INT,	0,"@@selectminbits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 370 "ext/Config/Config_xs.in"
+#line 378 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2401,	T_BOO,	0,"@@d_getprotoprotos@@"},
-#line 1206 "ext/Config/Config_xs.in"
+#line 1214 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2402,		T_INT,	0,"@@u16size@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 598 "ext/Config/Config_xs.in"
+#line 606 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2409,		T_BOO,	0,"@@d_signbit@@"},
-#line 263 "ext/Config/Config_xs.in"
+#line 271 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2410,		T_BOO,	0,"@@d_dosuid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 254 "ext/Config/Config_xs.in"
+#line 262 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2415,		T_BOO,	0,"@@d_difftime@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1004 "ext/Config/Config_xs.in"
+#line 1012 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2419,		T_STR,	0,"@@mips_type@@"},
       {-1, -1, 0, NULL},
-#line 69 "ext/Config/Config_xs.in"
+#line 77 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2421,			T_EMP,	0,"@@Author@@"},
-#line 630 "ext/Config/Config_xs.in"
+#line 638 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2422,		T_BOO,	0,"@@d_stdstdio@@"},
       {-1, -1, 0, NULL},
-#line 959 "ext/Config/Config_xs.in"
+#line 967 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2424,		T_STR,	0,"@@libperl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 171 "ext/Config/Config_xs.in"
+#line 179 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2432,		T_STR,	0,"@@cppccsymbols@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 871 "ext/Config/Config_xs.in"
+#line 879 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2435,		T_BOO,	0,"@@i_sysin@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 450 "ext/Config/Config_xs.in"
+#line 458 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2439,		T_BOO,	0,"@@d_mblen@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 697 "ext/Config/Config_xs.in"
+#line 705 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2450,		T_BOO,	0,"@@d_wcscmp@@"},
-#line 1265 "ext/Config/Config_xs.in"
+#line 1273 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2451,		T_STR,	0,"@@vendorbin@@"},
       {-1, -1, 0, NULL},
-#line 485 "ext/Config/Config_xs.in"
+#line 493 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2453,			T_BOO,	0,"@@d_ndbm@@"},
-#line 494 "ext/Config/Config_xs.in"
+#line 502 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2454,		T_BOO,	0,"@@d_off64_t@@"},
-#line 395 "ext/Config/Config_xs.in"
+#line 403 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2455,	T_BOO,	0,"@@d_inc_version_list@@"},
-#line 310 "ext/Config/Config_xs.in"
+#line 318 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2456,		T_BOO,	0,"@@d_fpathconf@@"},
-#line 1210 "ext/Config/Config_xs.in"
+#line 1218 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2457,		T_INT,	0,"@@u64size@@"},
-#line 846 "ext/Config/Config_xs.in"
+#line 854 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2458,			T_BOO,	0,"@@i_ndbm@@"},
-#line 365 "ext/Config/Config_xs.in"
+#line 373 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2459,		T_BOO,	0,"@@d_getppid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1280 "ext/Config/Config_xs.in"
+#line 1288 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2464,		T_STR,	0,"@@vendorscript@@"},
       {-1, -1, 0, NULL},
-#line 861 "ext/Config/Config_xs.in"
+#line 869 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2466,		T_BOO,	0,"@@i_stdbool@@"},
-#line 134 "ext/Config/Config_xs.in"
+#line 142 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2467,		T_STR,	0,"@@cf_time@@"},
       {-1, -1, 0, NULL},
-#line 814 "ext/Config/Config_xs.in"
+#line 822 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2469,			T_STR,	0,"@@i8type@@"},
       {-1, -1, 0, NULL},
-#line 686 "ext/Config/Config_xs.in"
+#line 694 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2471,		T_BOO,	0,"@@d_vendorscript@@"},
-#line 1230 "ext/Config/Config_xs.in"
+#line 1238 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2472,		T_BOO,	0,"@@usefaststdio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1117 "ext/Config/Config_xs.in"
+#line 1125 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2478,	T_INT,	0,"@@setpwent_r_proto@@"},
-#line 320 "ext/Config/Config_xs.in"
+#line 328 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2479,		T_BOO,	0,"@@d_fstatfs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1151 "ext/Config/Config_xs.in"
+#line 1159 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2484,		T_STR,	0,"@@sitescriptexp@@"},
-#line 396 "ext/Config/Config_xs.in"
+#line 404 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2485,		T_BOO,	0,"@@d_index@@"},
       {-1, -1, 0, NULL},
-#line 877 "ext/Config/Config_xs.in"
+#line 885 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2487,		T_BOO,	0,"@@i_sysndir@@"},
-#line 661 "ext/Config/Config_xs.in"
+#line 669 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2488,		T_BOO,	0,"@@d_tgamma@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 391 "ext/Config/Config_xs.in"
+#line 399 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2492,		T_BOO,	0,"@@d_htonl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 436 "ext/Config/Config_xs.in"
+#line 444 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2497,		T_BOO,	0,"@@d_log1p@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 237 "ext/Config/Config_xs.in"
+#line 245 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2507,		T_BOO,	0,"@@d_clearenv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 843 "ext/Config/Config_xs.in"
+#line 851 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2511,			T_BOO,	0,"@@i_math@@"},
-#line 1281 "ext/Config/Config_xs.in"
+#line 1289 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2512,	T_STR,	0,"@@vendorscriptexp@@"},
-#line 684 "ext/Config/Config_xs.in"
+#line 692 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2513,		T_BOO,	0,"@@d_vendorbin@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 422 "ext/Config/Config_xs.in"
+#line 430 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2518,		T_BOO,	0,"@@d_lgamma@@"},
       {-1, -1, 0, NULL},
-#line 387 "ext/Config/Config_xs.in"
+#line 395 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2520,		T_BOO,	0,"@@d_gmtime_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 255 "ext/Config/Config_xs.in"
+#line 263 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2527,		T_BOO,	0,"@@d_difftime64@@"},
-#line 1128 "ext/Config/Config_xs.in"
+#line 1136 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2528,		T_STR,	0,"@@sig_name_init@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 717 "ext/Config/Config_xs.in"
+#line 725 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2532,		T_INT,	0,"@@doublesize@@"},
-#line 1000 "ext/Config/Config_xs.in"
+#line 1008 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2533,		T_INT,	0,"@@man1ext@@"},
       {-1, -1, 0, NULL},
-#line 97 "ext/Config/Config_xs.in"
+#line 105 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2535,		T_STR,	0,"@@aphostname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1003 "ext/Config/Config_xs.in"
+#line 1011 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2538,		T_INT,	0,"@@man3ext@@"},
       {-1, -1, 0, NULL},
-#line 1274 "ext/Config/Config_xs.in"
+#line 1282 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2540,		T_STR,	0,"@@vendorman1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1276 "ext/Config/Config_xs.in"
+#line 1284 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2545,		T_STR,	0,"@@vendorman3dir@@"},
-#line 434 "ext/Config/Config_xs.in"
+#line 442 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2546,		T_BOO,	0,"@@d_locconv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 414 "ext/Config/Config_xs.in"
+#line 422 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2557,		T_BOO,	0,"@@d_isnormal@@"},
       {-1, -1, 0, NULL},
-#line 565 "ext/Config/Config_xs.in"
+#line 573 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2559,		T_BOO,	0,"@@d_sethostent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 103 "ext/Config/Config_xs.in"
+#line 111 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2572,		T_STR,	0,"@@archlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 138 "ext/Config/Config_xs.in"
+#line 146 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2575,			T_STR,	0,"@@chmod@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 731 "ext/Config/Config_xs.in"
+#line 739 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2578,	T_INT,	0,"@@endpwent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 714 "ext/Config/Config_xs.in"
+#line 722 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2582,		T_INT,	0,"@@doublekind@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1208 "ext/Config/Config_xs.in"
+#line 1216 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2592,		T_INT,	0,"@@u32size@@"},
-#line 535 "ext/Config/Config_xs.in"
+#line 543 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2593,		T_BOO,	0,"@@d_remainder@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 219 "ext/Config/Config_xs.in"
+#line 227 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2603,			T_BOO,	0,"@@d_bcmp@@"},
       {-1, -1, 0, NULL},
-#line 1111 "ext/Config/Config_xs.in"
+#line 1119 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2605,		T_STR,	0,"@@sendmail@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1201 "ext/Config/Config_xs.in"
+#line 1209 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2625,			T_STR,	0,"@@touch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1192 "ext/Config/Config_xs.in"
+#line 1200 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2640,		T_STR,	0,"@@targetport@@"},
       {-1, -1, 0, NULL},
-#line 857 "ext/Config/Config_xs.in"
+#line 865 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2642,		T_BOO,	0,"@@i_sgtty@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1113 "ext/Config/Config_xs.in"
+#line 1121 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2648,	T_INT,	0,"@@sethostent_r_proto@@"},
-#line 794 "ext/Config/Config_xs.in"
+#line 802 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2649,			T_STR,	0,"@@gzip@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1057 "ext/Config/Config_xs.in"
+#line 1065 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2658,		T_STR,	0,"@@perlpath@@"},
-#line 271 "ext/Config/Config_xs.in"
+#line 279 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2659,		T_BOO,	0,"@@d_endhostent_r@@"},
-#line 472 "ext/Config/Config_xs.in"
+#line 480 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2660,	T_BOO,	0,"@@d_msg_dontroute@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 390 "ext/Config/Config_xs.in"
+#line 398 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2666,		T_BOO,	0,"@@d_hasmntopt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1073 "ext/Config/Config_xs.in"
+#line 1081 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2670,		T_INT,	0,"@@randbits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1143 "ext/Config/Config_xs.in"
+#line 1151 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2678,		T_STR,	0,"@@sitelibexp@@"},
       {-1, -1, 0, NULL},
-#line 688 "ext/Config/Config_xs.in"
+#line 696 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2680,	T_BOO,	0,"@@d_vms_case_sensitive_symbols@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 927 "ext/Config/Config_xs.in"
+#line 935 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2686,		T_STR,	0,"@@installsitelib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 658 "ext/Config/Config_xs.in"
+#line 666 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2691,		T_BOO,	0,"@@d_tcsetpgrp@@"},
       {-1, -1, 0, NULL},
-#line 105 "ext/Config/Config_xs.in"
+#line 113 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2693,		T_STR,	0,"@@archname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 496 "ext/Config/Config_xs.in"
+#line 504 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2698,		T_BOO,	0,"@@d_oldpthreads@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 818 "ext/Config/Config_xs.in"
+#line 826 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2712,		T_STR,	0,"@@i_bsdioctl@@"},
-#line 476 "ext/Config/Config_xs.in"
+#line 484 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2713,		T_BOO,	0,"@@d_msgctl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 663 "ext/Config/Config_xs.in"
+#line 671 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2733,		T_BOO,	0,"@@d_timegm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 883 "ext/Config/Config_xs.in"
+#line 891 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2739,		T_BOO,	0,"@@i_syssockio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 698 "ext/Config/Config_xs.in"
+#line 706 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2747,		T_BOO,	0,"@@d_wcstombs@@"},
-#line 728 "ext/Config/Config_xs.in"
+#line 736 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2748,	T_INT,	0,"@@endhostent_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 840 "ext/Config/Config_xs.in"
+#line 848 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2750,		T_BOO,	0,"@@i_machcthr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 574 "ext/Config/Config_xs.in"
+#line 582 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2754,		T_BOO,	0,"@@d_setpgrp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 595 "ext/Config/Config_xs.in"
+#line 603 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2762,		T_BOO,	0,"@@d_shmdt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1083 "ext/Config/Config_xs.in"
+#line 1091 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2769,			T_STR,	0,"@@rm_try@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 655 "ext/Config/Config_xs.in"
+#line 663 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2774,		T_BOO,	0,"@@d_syserrlst@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1181 "ext/Config/Config_xs.in"
+#line 1189 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2778,			T_EMP,	0,"@@submit@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1271 "ext/Config/Config_xs.in"
+#line 1279 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2786,		T_STR,	0,"@@vendorlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 951 "ext/Config/Config_xs.in"
+#line 959 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2792,		T_STR,	0,"@@ldflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 799 "ext/Config/Config_xs.in"
+#line 807 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2802,		T_STR,	0,"@@hostcat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 947 "ext/Config/Config_xs.in"
+#line 955 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2805,			T_STR,	0,"@@ksh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 174 "ext/Config/Config_xs.in"
+#line 182 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2810,		T_STR,	0,"@@cppminus@@"},
       {-1, -1, 0, NULL},
-#line 471 "ext/Config/Config_xs.in"
+#line 479 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2812,		T_BOO,	0,"@@d_msg_ctrunc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1272 "ext/Config/Config_xs.in"
+#line 1280 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2816,		T_STR,	0,"@@vendorlib_stem@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1191 "ext/Config/Config_xs.in"
+#line 1199 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2833,		T_STR,	0,"@@targetmkdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 696 "ext/Config/Config_xs.in"
+#line 704 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2836,		T_BOO,	0,"@@d_waitpid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 435 "ext/Config/Config_xs.in"
+#line 443 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2839,		T_BOO,	0,"@@d_lockf@@"},
       {-1, -1, 0, NULL},
-#line 921 "ext/Config/Config_xs.in"
+#line 929 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2841,		T_STR,	0,"@@installprivlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 622 "ext/Config/Config_xs.in"
+#line 630 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2857,	T_BOO,	0,"@@d_static_inline@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 892 "ext/Config/Config_xs.in"
+#line 900 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2860,		T_BOO,	0,"@@i_sysun@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 481 "ext/Config/Config_xs.in"
+#line 489 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2865,		T_BOO,	0,"@@d_msync@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 817 "ext/Config/Config_xs.in"
+#line 825 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2872,			T_BOO,	0,"@@i_bfd@@"},
       {-1, -1, 0, NULL},
-#line 654 "ext/Config/Config_xs.in"
+#line 662 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2874,		T_STR,	0,"@@d_sysernlst@@"},
       {-1, -1, 0, NULL},
-#line 582 "ext/Config/Config_xs.in"
+#line 590 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2876,		T_BOO,	0,"@@d_setresgid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 423 "ext/Config/Config_xs.in"
+#line 431 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2890,		T_BOO,	0,"@@d_lgamma_r@@"},
       {-1, -1, 0, NULL},
-#line 879 "ext/Config/Config_xs.in"
+#line 887 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2892,		T_BOO,	0,"@@i_syspoll@@"},
       {-1, -1, 0, NULL},
-#line 1213 "ext/Config/Config_xs.in"
+#line 1221 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2894,			T_STR,	0,"@@u8type@@"},
-#line 1184 "ext/Config/Config_xs.in"
+#line 1192 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2895,		T_STR,	0,"@@sysroot@@"},
-#line 989 "ext/Config/Config_xs.in"
+#line 997 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2896,		T_STR,	0,"@@lseektype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 328 "ext/Config/Config_xs.in"
+#line 336 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2908,		T_BOO,	0,"@@d_getaddrinfo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 866 "ext/Config/Config_xs.in"
+#line 874 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2911,		T_BOO,	0,"@@i_sunmath@@"},
-#line 304 "ext/Config/Config_xs.in"
+#line 312 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2912,			T_BOO,	0,"@@d_fmax@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 109 "ext/Config/Config_xs.in"
+#line 117 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2917,			T_STR,	0,"@@awk@@"},
       {-1, -1, 0, NULL},
-#line 930 "ext/Config/Config_xs.in"
+#line 938 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2919,	T_STR,	0,"@@installsitescript@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 106 "ext/Config/Config_xs.in"
+#line 114 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2925,		T_STR,	0,"@@archname64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 588 "ext/Config/Config_xs.in"
+#line 596 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2931,		T_BOO,	0,"@@d_setservent_r@@"},
-#line 592 "ext/Config/Config_xs.in"
+#line 600 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2932,		T_BOO,	0,"@@d_shmat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 556 "ext/Config/Config_xs.in"
+#line 564 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2943,		T_BOO,	0,"@@d_semget@@"},
-#line 203 "ext/Config/Config_xs.in"
+#line 211 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2944,		T_BOO,	0,"@@d_archlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1287 "ext/Config/Config_xs.in"
+#line 1295 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2947,			T_STR,	0,"@@yacc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1166 "ext/Config/Config_xs.in"
+#line 1174 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2954,		T_STR,	0,"@@ssizetype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 583 "ext/Config/Config_xs.in"
+#line 591 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2963,		T_BOO,	0,"@@d_setresuid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 258 "ext/Config/Config_xs.in"
+#line 266 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2968,		T_BOO,	0,"@@d_dirnamlen@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 253 "ext/Config/Config_xs.in"
+#line 261 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2981,		T_BOO,	0,"@@d_dbminitproto@@"},
-#line 199 "ext/Config/Config_xs.in"
+#line 207 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2982,		T_BOO,	0,"@@d_accessx@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 575 "ext/Config/Config_xs.in"
+#line 583 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2985,		T_BOO,	0,"@@d_setpgrp2@@"},
-#line 623 "ext/Config/Config_xs.in"
+#line 631 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2986,		T_BOO,	0,"@@d_statvfs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 227 "ext/Config/Config_xs.in"
+#line 235 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str2989,		T_BOO,	0,"@@d_bzero@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 944 "ext/Config/Config_xs.in"
+#line 952 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3003,			T_INT,	0,"@@ivsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 262 "ext/Config/Config_xs.in"
+#line 270 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3007,		T_BOO,	0,"@@d_dlsymun@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 594 "ext/Config/Config_xs.in"
+#line 602 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3013,		T_BOO,	0,"@@d_shmctl@@"},
-#line 1183 "ext/Config/Config_xs.in"
+#line 1191 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3014,			T_STR,	0,"@@sysman@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 687 "ext/Config/Config_xs.in"
+#line 695 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3029,		T_BOO,	0,"@@d_vfork@@"},
       {-1, -1, 0, NULL},
-#line 279 "ext/Config/Config_xs.in"
+#line 287 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3031,		T_BOO,	0,"@@d_endservent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 905 "ext/Config/Config_xs.in"
+#line 913 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3034,		T_BOO,	0,"@@i_vfork@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 826 "ext/Config/Config_xs.in"
+#line 834 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3038,			T_BOO,	0,"@@i_fenv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 534 "ext/Config/Config_xs.in"
+#line 542 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3049,		T_BOO,	0,"@@d_regcomp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 679 "ext/Config/Config_xs.in"
+#line 687 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3052,		T_BOO,	0,"@@d_unsetenv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 244 "ext/Config/Config_xs.in"
+#line 252 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3065,		T_BOO,	0,"@@d_crypt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 819 "ext/Config/Config_xs.in"
+#line 827 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3070,		T_BOO,	0,"@@i_crypt@@"},
       {-1, -1, 0, NULL},
-#line 788 "ext/Config/Config_xs.in"
+#line 796 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3072,			T_STR,	0,"@@gmake@@"},
       {-1, -1, 0, NULL},
-#line 509 "ext/Config/Config_xs.in"
+#line 517 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3074,		T_BOO,	0,"@@d_procselfexe@@"},
       {-1, -1, 0, NULL},
-#line 977 "ext/Config/Config_xs.in"
+#line 985 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3076,		T_STR,	0,"@@loclibpth@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 245 "ext/Config/Config_xs.in"
+#line 253 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3082,		T_BOO,	0,"@@d_crypt_r@@"},
       {-1, -1, 0, NULL},
-#line 853 "ext/Config/Config_xs.in"
+#line 861 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3084,		T_BOO,	0,"@@i_pthread@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 999 "ext/Config/Config_xs.in"
+#line 1007 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3088,		T_STR,	0,"@@man1direxp@@"},
-#line 913 "ext/Config/Config_xs.in"
+#line 921 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3089,		T_STR,	0,"@@installarchlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1002 "ext/Config/Config_xs.in"
+#line 1010 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3093,		T_STR,	0,"@@man3direxp@@"},
-#line 378 "ext/Config/Config_xs.in"
+#line 386 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3094,		T_BOO,	0,"@@d_getsent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 874 "ext/Config/Config_xs.in"
+#line 882 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3097,		T_BOO,	0,"@@i_sysmman@@"},
-#line 1036 "ext/Config/Config_xs.in"
+#line 1044 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3098,			T_INT,	0,"@@nvsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1050 "ext/Config/Config_xs.in"
+#line 1058 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3113,		T_STR,	0,"@@path_sep@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 872 "ext/Config/Config_xs.in"
+#line 880 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3118,		T_BOO,	0,"@@i_sysioctl@@"},
-#line 919 "ext/Config/Config_xs.in"
+#line 927 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3119,		T_STR,	0,"@@installprefix@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 349 "ext/Config/Config_xs.in"
+#line 357 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3126,		T_BOO,	0,"@@d_getmntent@@"},
-#line 692 "ext/Config/Config_xs.in"
+#line 700 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3127,		T_BOO,	0,"@@d_volatile@@"},
       {-1, -1, 0, NULL},
-#line 510 "ext/Config/Config_xs.in"
+#line 518 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3129,		T_BOO,	0,"@@d_pseudofork@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 689 "ext/Config/Config_xs.in"
+#line 697 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3132,	T_BOO,	0,"@@d_void_closedir@@"},
-#line 291 "ext/Config/Config_xs.in"
+#line 299 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3133,	T_BOO,	0,"@@d_fcntl_can_lock@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 361 "ext/Config/Config_xs.in"
+#line 369 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3139,		T_BOO,	0,"@@d_getpent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 238 "ext/Config/Config_xs.in"
+#line 246 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3142,		T_BOO,	0,"@@d_closedir@@"},
-#line 1171 "ext/Config/Config_xs.in"
+#line 1179 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3143,		T_STR,	0,"@@static_ext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 316 "ext/Config/Config_xs.in"
+#line 324 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3154,		T_BOO,	0,"@@d_frexpl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 694 "ext/Config/Config_xs.in"
+#line 702 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3158,		T_BOO,	0,"@@d_vsnprintf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 593 "ext/Config/Config_xs.in"
+#line 601 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3161,	T_BOO,	0,"@@d_shmatprototype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 372 "ext/Config/Config_xs.in"
+#line 380 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3166,		T_BOO,	0,"@@d_getpwent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 648 "ext/Config/Config_xs.in"
+#line 656 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3170,		T_BOO,	0,"@@d_strxfrm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 311 "ext/Config/Config_xs.in"
+#line 319 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3176,		T_BOO,	0,"@@d_fpclass@@"},
-#line 124 "ext/Config/Config_xs.in"
+#line 132 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3177,		T_STR,	0,"@@ccflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 331 "ext/Config/Config_xs.in"
+#line 339 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3186,		T_BOO,	0,"@@d_getfsstat@@"},
       {-1, -1, 0, NULL},
-#line 373 "ext/Config/Config_xs.in"
+#line 381 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3188,		T_BOO,	0,"@@d_getpwent_r@@"},
       {-1, -1, 0, NULL},
-#line 499 "ext/Config/Config_xs.in"
+#line 507 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3190,		T_BOO,	0,"@@d_pathconf@@"},
-#line 917 "ext/Config/Config_xs.in"
+#line 925 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3191,		T_STR,	0,"@@installman1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 918 "ext/Config/Config_xs.in"
+#line 926 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3196,		T_STR,	0,"@@installman3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 353 "ext/Config/Config_xs.in"
+#line 361 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3199,		T_BOO,	0,"@@d_getnent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 844 "ext/Config/Config_xs.in"
+#line 852 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3206,		T_BOO,	0,"@@i_memory@@"},
       {-1, -1, 0, NULL},
-#line 548 "ext/Config/Config_xs.in"
+#line 556 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3208,		T_BOO,	0,"@@d_sched_yield@@"},
       {-1, -1, 0, NULL},
-#line 432 "ext/Config/Config_xs.in"
+#line 440 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3210,		T_BOO,	0,"@@d_localtime_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 599 "ext/Config/Config_xs.in"
+#line 607 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3215,		T_BOO,	0,"@@d_sigprocmask@@"},
       {-1, -1, 0, NULL},
-#line 313 "ext/Config/Config_xs.in"
+#line 321 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3217,		T_BOO,	0,"@@d_fpclassl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 536 "ext/Config/Config_xs.in"
+#line 544 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3230,		T_BOO,	0,"@@d_remquo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 928 "ext/Config/Config_xs.in"
+#line 936 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3235,	T_STR,	0,"@@installsiteman1dir@@"},
-#line 1178 "ext/Config/Config_xs.in"
+#line 1186 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3236,	T_STR,	0,"@@stdio_stream_array@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 929 "ext/Config/Config_xs.in"
+#line 937 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3240,	T_STR,	0,"@@installsiteman3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 220 "ext/Config/Config_xs.in"
+#line 228 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3254,		T_BOO,	0,"@@d_bcopy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 667 "ext/Config/Config_xs.in"
+#line 675 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3267,		T_BOO,	0,"@@d_tmpnam_r@@"},
-#line 604 "ext/Config/Config_xs.in"
+#line 612 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3268,		T_BOO,	0,"@@d_sockaddr_in6@@"},
-#line 789 "ext/Config/Config_xs.in"
+#line 797 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3269,		T_INT,	0,"@@gmtime_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 329 "ext/Config/Config_xs.in"
+#line 337 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3274,		T_BOO,	0,"@@d_getcwd@@"},
       {-1, -1, 0, NULL},
-#line 1103 "ext/Config/Config_xs.in"
+#line 1111 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3276,		T_STR,	0,"@@sSCNfldbl@@"},
-#line 584 "ext/Config/Config_xs.in"
+#line 592 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3277,		T_BOO,	0,"@@d_setreuid@@"},
       {-1, -1, 0, NULL},
-#line 734 "ext/Config/Config_xs.in"
+#line 742 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3279,		T_STR,	0,"@@exe_ext@@"},
       {-1, -1, 0, NULL},
-#line 837 "ext/Config/Config_xs.in"
+#line 845 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3281,		T_BOO,	0,"@@i_libutil@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 932 "ext/Config/Config_xs.in"
+#line 940 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3284,	T_BOO,	0,"@@installusrbinperl@@"},
       {-1, -1, 0, NULL},
-#line 389 "ext/Config/Config_xs.in"
+#line 397 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3286,		T_BOO,	0,"@@d_grpasswd@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1097 "ext/Config/Config_xs.in"
+#line 1105 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3291,		T_STR,	0,"@@sPRIfldbl@@"},
       {-1, -1, 0, NULL},
-#line 228 "ext/Config/Config_xs.in"
+#line 236 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3293,	T_BOO,	0,"@@d_c99_variadic_macros@@"},
       {-1, -1, 0, NULL},
-#line 673 "ext/Config/Config_xs.in"
+#line 681 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3295,		T_BOO,	0,"@@d_u32align@@"},
       {-1, -1, 0, NULL},
-#line 775 "ext/Config/Config_xs.in"
+#line 783 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3297,		T_INT,	0,"@@gidsign@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 431 "ext/Config/Config_xs.in"
+#line 439 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3300,		T_BOO,	0,"@@d_localtime64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 336 "ext/Config/Config_xs.in"
+#line 344 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3304,		T_BOO,	0,"@@d_getgrps@@"},
       {-1, -1, 0, NULL},
-#line 964 "ext/Config/Config_xs.in"
+#line 972 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3306,		T_STR,	0,"@@libsfiles@@"},
       {-1, -1, 0, NULL},
-#line 876 "ext/Config/Config_xs.in"
+#line 884 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3308,		T_BOO,	0,"@@i_sysmount@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 774 "ext/Config/Config_xs.in"
+#line 782 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3314,		T_STR,	0,"@@gidformat@@"},
-#line 332 "ext/Config/Config_xs.in"
+#line 340 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3315,		T_BOO,	0,"@@d_getgrent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1162 "ext/Config/Config_xs.in"
+#line 1170 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3319,		T_STR,	0,"@@spitshell@@"},
-#line 482 "ext/Config/Config_xs.in"
+#line 490 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3320,		T_BOO,	0,"@@d_munmap@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 512 "ext/Config/Config_xs.in"
+#line 520 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3328,	T_BOO,	0,"@@d_pthread_attr_setscope@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 433 "ext/Config/Config_xs.in"
+#line 441 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3332,	T_BOO,	0,"@@d_localtime_r_needs_tzset@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 333 "ext/Config/Config_xs.in"
+#line 341 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3337,		T_BOO,	0,"@@d_getgrent_r@@"},
-#line 882 "ext/Config/Config_xs.in"
+#line 890 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3338,		T_BOO,	0,"@@i_sysselct@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 815 "ext/Config/Config_xs.in"
+#line 823 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3342,		T_BOO,	0,"@@i_arpainet@@"},
-#line 172 "ext/Config/Config_xs.in"
+#line 180 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3343,		T_STR,	0,"@@cppflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1174 "ext/Config/Config_xs.in"
+#line 1182 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3357,		T_STR,	0,"@@stdio_bufsiz@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1060 "ext/Config/Config_xs.in"
+#line 1068 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3370,		T_STR,	0,"@@pidtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 808 "ext/Config/Config_xs.in"
+#line 816 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3375,		T_STR,	0,"@@i16type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 297 "ext/Config/Config_xs.in"
+#line 305 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3379,		T_BOO,	0,"@@d_fgetpos@@"},
-#line 417 "ext/Config/Config_xs.in"
+#line 425 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3380,		T_BOO,	0,"@@d_killpg@@"},
-#line 140 "ext/Config/Config_xs.in"
+#line 148 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3381,		T_STR,	0,"@@clocktype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 322 "ext/Config/Config_xs.in"
+#line 330 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3385,		T_BOO,	0,"@@d_fsync@@"},
-#line 461 "ext/Config/Config_xs.in"
+#line 469 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3386,		T_BOO,	0,"@@d_mkstemp@@"},
-#line 462 "ext/Config/Config_xs.in"
+#line 470 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3387,		T_BOO,	0,"@@d_mkstemps@@"},
       {-1, -1, 0, NULL},
-#line 766 "ext/Config/Config_xs.in"
+#line 774 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3389,	T_INT,	0,"@@getprotoent_r_proto@@"},
-#line 1227 "ext/Config/Config_xs.in"
+#line 1235 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3390,		T_BOO,	0,"@@usedevel@@"},
-#line 459 "ext/Config/Config_xs.in"
+#line 467 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3391,		T_BOO,	0,"@@d_mkdtemp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 564 "ext/Config/Config_xs.in"
+#line 572 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3394,		T_BOO,	0,"@@d_sethent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 763 "ext/Config/Config_xs.in"
+#line 771 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3397,	T_INT,	0,"@@getnetent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1114 "ext/Config/Config_xs.in"
+#line 1122 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3414,	T_INT,	0,"@@setlocale_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 884 "ext/Config/Config_xs.in"
+#line 892 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3417,		T_BOO,	0,"@@i_sysstat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1161 "ext/Config/Config_xs.in"
+#line 1169 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3420,		T_STR,	0,"@@spackage@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1258 "ext/Config/Config_xs.in"
+#line 1266 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3428,			T_INT,	0,"@@uvsize@@"},
       {-1, -1, 0, NULL},
-#line 812 "ext/Config/Config_xs.in"
+#line 820 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3430,		T_STR,	0,"@@i64type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1168 "ext/Config/Config_xs.in"
+#line 1176 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3438,		T_INT,	0,"@@st_ino_size@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1035 "ext/Config/Config_xs.in"
+#line 1043 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3447,		T_INT,	0,"@@nvmantbits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1250 "ext/Config/Config_xs.in"
+#line 1258 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3450,		T_BOO,	0,"@@usethreads@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1286 "ext/Config/Config_xs.in"
+#line 1294 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3460,		T_STR,	0,"@@xlibpth@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 605 "ext/Config/Config_xs.in"
+#line 613 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3476,	T_BOO,	0,"@@d_sockaddr_sa_len@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 270 "ext/Config/Config_xs.in"
+#line 278 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3494,		T_BOO,	0,"@@d_endhent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 288 "ext/Config/Config_xs.in"
+#line 296 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3498,		T_BOO,	0,"@@d_fchmod@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 880 "ext/Config/Config_xs.in"
+#line 888 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3503,		T_BOO,	0,"@@i_sysresrc@@"},
-#line 114 "ext/Config/Config_xs.in"
+#line 122 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3504,			T_STR,	0,"@@binexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 881 "ext/Config/Config_xs.in"
+#line 889 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3508,		T_BOO,	0,"@@i_syssecrt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1229 "ext/Config/Config_xs.in"
+#line 1237 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3516,		T_BOO,	0,"@@usedtrace@@"},
-#line 603 "ext/Config/Config_xs.in"
+#line 611 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3517,		T_BOO,	0,"@@d_snprintf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 691 "ext/Config/Config_xs.in"
+#line 699 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3521,		T_EMP,	0,"@@d_voidtty@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1198 "ext/Config/Config_xs.in"
+#line 1206 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3526,		T_STR,	0,"@@timetype@@"},
       {-1, -1, 0, NULL},
-#line 736 "ext/Config/Config_xs.in"
+#line 744 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3528,		T_STR,	0,"@@extensions@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 776 "ext/Config/Config_xs.in"
+#line 784 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3532,		T_INT,	0,"@@gidsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 915 "ext/Config/Config_xs.in"
+#line 923 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3535,	T_STR,	0,"@@installhtml1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 916 "ext/Config/Config_xs.in"
+#line 924 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3540,	T_STR,	0,"@@installhtml3dir@@"},
-#line 178 "ext/Config/Config_xs.in"
+#line 186 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3541,		T_INT,	0,"@@crypt_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 292 "ext/Config/Config_xs.in"
+#line 300 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3548,		T_BOO,	0,"@@d_fd_macros@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 931 "ext/Config/Config_xs.in"
+#line 939 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3555,		T_STR,	0,"@@installstyle@@"},
       {-1, -1, 0, NULL},
-#line 795 "ext/Config/Config_xs.in"
+#line 803 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3557,		T_STR,	0,"@@h_fcntl@@"},
       {-1, -1, 0, NULL},
-#line 357 "ext/Config/Config_xs.in"
+#line 365 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3559,		T_BOO,	0,"@@d_getnetprotos@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 521 "ext/Config/Config_xs.in"
+#line 529 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3563,		T_BOO,	0,"@@d_pwpasswd@@"},
       {-1, -1, 0, NULL},
-#line 810 "ext/Config/Config_xs.in"
+#line 818 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3565,		T_STR,	0,"@@i32type@@"},
-#line 1008 "ext/Config/Config_xs.in"
+#line 1016 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3566,		T_STR,	0,"@@modetype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1235 "ext/Config/Config_xs.in"
+#line 1243 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3570,		T_BOO,	0,"@@usemallocwrap@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 296 "ext/Config/Config_xs.in"
+#line 304 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3577,		T_BOO,	0,"@@d_fegetround@@"},
-#line 749 "ext/Config/Config_xs.in"
+#line 757 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3578,		T_STR,	0,"@@full_csh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 902 "ext/Config/Config_xs.in"
+#line 910 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3585,		T_BOO,	0,"@@i_values@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 520 "ext/Config/Config_xs.in"
+#line 528 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3591,		T_BOO,	0,"@@d_pwgecos@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 710 "ext/Config/Config_xs.in"
+#line 718 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3598,		T_BOO,	0,"@@dl_so_eq_ext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 362 "ext/Config/Config_xs.in"
+#line 370 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3604,		T_BOO,	0,"@@d_getpgid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1038 "ext/Config/Config_xs.in"
+#line 1046 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3619,		T_STR,	0,"@@o_nonblock@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 314 "ext/Config/Config_xs.in"
+#line 322 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3622,		T_BOO,	0,"@@d_fpgetround@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 205 "ext/Config/Config_xs.in"
+#line 213 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3633,		T_BOO,	0,"@@d_asctime_r@@"},
       {-1, -1, 0, NULL},
-#line 133 "ext/Config/Config_xs.in"
+#line 141 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3635,		T_STR,	0,"@@cf_email@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 403 "ext/Config/Config_xs.in"
+#line 411 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3638,		T_BOO,	0,"@@d_ipv6_mreq@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 489 "ext/Config/Config_xs.in"
+#line 497 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3644,		T_BOO,	0,"@@d_nexttoward@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 438 "ext/Config/Config_xs.in"
+#line 446 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3653,			T_BOO,	0,"@@d_logb@@"},
-#line 787 "ext/Config/Config_xs.in"
+#line 795 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3654,		T_STR,	0,"@@glibpth@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 656 "ext/Config/Config_xs.in"
+#line 664 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3676,		T_BOO,	0,"@@d_system@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 867 "ext/Config/Config_xs.in"
+#line 875 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3679,		T_BOO,	0,"@@i_sysaccess@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 972 "ext/Config/Config_xs.in"
+#line 980 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3684,		T_STR,	0,"@@lkflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 943 "ext/Config/Config_xs.in"
+#line 951 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3701,		T_STR,	0,"@@ivdformat@@"},
       {-1, -1, 0, NULL},
-#line 177 "ext/Config/Config_xs.in"
+#line 185 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3703,		T_STR,	0,"@@cppsymbols@@"},
       {-1, -1, 0, NULL},
-#line 772 "ext/Config/Config_xs.in"
+#line 780 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3705,	T_INT,	0,"@@getservent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 518 "ext/Config/Config_xs.in"
+#line 526 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3708,		T_BOO,	0,"@@d_pwcomment@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 356 "ext/Config/Config_xs.in"
+#line 364 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3718,		T_BOO,	0,"@@d_getnetent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 875 "ext/Config/Config_xs.in"
+#line 883 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3722,		T_BOO,	0,"@@i_sysmode@@"},
-#line 204 "ext/Config/Config_xs.in"
+#line 212 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3723,		T_BOO,	0,"@@d_asctime64@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1193 "ext/Config/Config_xs.in"
+#line 1201 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3728,		T_STR,	0,"@@targetsh@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 545 "ext/Config/Config_xs.in"
+#line 553 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3735,		T_BOO,	0,"@@d_sbrkproto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 693 "ext/Config/Config_xs.in"
+#line 701 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3751,		T_BOO,	0,"@@d_vprintf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 419 "ext/Config/Config_xs.in"
+#line 427 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3759,		T_BOO,	0,"@@d_lchown@@"},
-#line 1217 "ext/Config/Config_xs.in"
+#line 1225 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3760,		T_STR,	0,"@@uidtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1220 "ext/Config/Config_xs.in"
+#line 1228 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3769,		T_STR,	0,"@@uquadtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 137 "ext/Config/Config_xs.in"
+#line 145 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3780,			T_STR,	0,"@@chgrp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 330 "ext/Config/Config_xs.in"
+#line 338 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3783,		T_BOO,	0,"@@d_getespwnam@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1032 "ext/Config/Config_xs.in"
+#line 1040 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3791,		T_STR,	0,"@@nveformat@@"},
       {-1, -1, 0, NULL},
-#line 995 "ext/Config/Config_xs.in"
+#line 1003 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3793,		T_STR,	0,"@@mallocobj@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1207 "ext/Config/Config_xs.in"
+#line 1215 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3800,		T_STR,	0,"@@u16type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 754 "ext/Config/Config_xs.in"
+#line 762 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3806,	T_INT,	0,"@@getgrent_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 1110 "ext/Config/Config_xs.in"
+#line 1118 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3808,		T_STR,	0,"@@selecttype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 371 "ext/Config/Config_xs.in"
+#line 379 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3818,		T_BOO,	0,"@@d_getprpwnam@@"},
-#line 783 "ext/Config/Config_xs.in"
+#line 791 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3819,		T_STR,	0,"@@git_describe@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1268 "ext/Config/Config_xs.in"
+#line 1276 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3825,	T_STR,	0,"@@vendorhtml1direxp@@"},
       {-1, -1, 0, NULL},
-#line 800 "ext/Config/Config_xs.in"
+#line 808 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3827,		T_STR,	0,"@@hostgenerate@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1270 "ext/Config/Config_xs.in"
+#line 1278 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3830,	T_STR,	0,"@@vendorhtml3direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 128 "ext/Config/Config_xs.in"
+#line 136 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3835,		T_STR,	0,"@@ccstdflags@@"},
-#line 1243 "ext/Config/Config_xs.in"
+#line 1251 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3836,		T_STR,	0,"@@useposix@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 508 "ext/Config/Config_xs.in"
+#line 516 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3840,	T_BOO,	0,"@@d_printf_format_null@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 956 "ext/Config/Config_xs.in"
+#line 964 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3845,		T_STR,	0,"@@lib_ext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 665 "ext/Config/Config_xs.in"
+#line 673 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3849,		T_BOO,	0,"@@d_tm_tm_gmtoff@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1211 "ext/Config/Config_xs.in"
+#line 1219 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3855,		T_STR,	0,"@@u64type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 893 "ext/Config/Config_xs.in"
+#line 901 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3865,		T_BOO,	0,"@@i_sysutsname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 597 "ext/Config/Config_xs.in"
+#line 605 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3878,		T_BOO,	0,"@@d_sigaction@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 99 "ext/Config/Config_xs.in"
+#line 107 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3881,		T_INT,	0,"@@api_subversion@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 340 "ext/Config/Config_xs.in"
+#line 348 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3885,		T_BOO,	0,"@@d_gethname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 702 "ext/Config/Config_xs.in"
+#line 710 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3891,		T_BOO,	0,"@@d_xenix@@"},
-#line 602 "ext/Config/Config_xs.in"
+#line 610 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3892,		T_BOO,	0,"@@d_sitearch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 460 "ext/Config/Config_xs.in"
+#line 468 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3895,		T_BOO,	0,"@@d_mkfifo@@"},
       {-1, -1, 0, NULL},
-#line 864 "ext/Config/Config_xs.in"
+#line 872 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3897,		T_BOO,	0,"@@i_stdlib@@"},
-#line 600 "ext/Config/Config_xs.in"
+#line 608 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3898,		T_BOO,	0,"@@d_sigsetjmp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1124 "ext/Config/Config_xs.in"
+#line 1132 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3909,		T_STR,	0,"@@shrpenv@@"},
-#line 1266 "ext/Config/Config_xs.in"
+#line 1274 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3910,		T_STR,	0,"@@vendorbinexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1042 "ext/Config/Config_xs.in"
+#line 1050 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3927,		T_STR,	0,"@@orderlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 252 "ext/Config/Config_xs.in"
+#line 260 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3931,		T_BOO,	0,"@@d_dbl_dig@@"},
       {-1, -1, 0, NULL},
-#line 934 "ext/Config/Config_xs.in"
+#line 942 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3933,	T_STR,	0,"@@installvendorbin@@"},
-#line 975 "ext/Config/Config_xs.in"
+#line 983 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3934,	T_INT,	0,"@@localtime_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 440 "ext/Config/Config_xs.in"
+#line 448 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3940,		T_BOO,	0,"@@d_longlong@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 960 "ext/Config/Config_xs.in"
+#line 968 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3943,			T_STR,	0,"@@libpth@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1068 "ext/Config/Config_xs.in"
+#line 1076 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3952,		T_STR,	0,"@@procselfexe@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 629 "ext/Config/Config_xs.in"
+#line 637 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3955,		T_BOO,	0,"@@d_stdiobase@@"},
-#line 110 "ext/Config/Config_xs.in"
+#line 118 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3956,		T_STR,	0,"@@baserev@@"},
       {-1, -1, 0, NULL},
-#line 830 "ext/Config/Config_xs.in"
+#line 838 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3958,			T_BOO,	0,"@@i_gdbm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1098 "ext/Config/Config_xs.in"
+#line 1106 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3986,		T_STR,	0,"@@sPRIgldbl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1209 "ext/Config/Config_xs.in"
+#line 1217 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3990,		T_STR,	0,"@@u32type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 903 "ext/Config/Config_xs.in"
+#line 911 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3996,		T_BOO,	0,"@@i_varargs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1275 "ext/Config/Config_xs.in"
+#line 1283 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str3999,	T_STR,	0,"@@vendorman1direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1277 "ext/Config/Config_xs.in"
+#line 1285 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4004,	T_STR,	0,"@@vendorman3direxp@@"},
-#line 858 "ext/Config/Config_xs.in"
+#line 866 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4005,		T_BOO,	0,"@@i_shadow@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 633 "ext/Config/Config_xs.in"
+#line 641 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4008,		T_BOO,	0,"@@d_strctcpy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 111 "ext/Config/Config_xs.in"
+#line 119 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4011,			T_STR,	0,"@@bash@@"},
       {-1, -1, 0, NULL},
-#line 483 "ext/Config/Config_xs.in"
+#line 491 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4013,		T_BOO,	0,"@@d_mymalloc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 690 "ext/Config/Config_xs.in"
+#line 698 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4016,		T_BOO,	0,"@@d_voidsig@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 610 "ext/Config/Config_xs.in"
+#line 618 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4019,		T_BOO,	0,"@@d_sockpair@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 448 "ext/Config/Config_xs.in"
+#line 456 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4023,	T_BOO,	0,"@@d_malloc_good_size@@"},
       {-1, -1, 0, NULL},
-#line 479 "ext/Config/Config_xs.in"
+#line 487 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4025,		T_BOO,	0,"@@d_msgrcv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1046 "ext/Config/Config_xs.in"
+#line 1054 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4029,		T_STR,	0,"@@package@@"},
-#line 855 "ext/Config/Config_xs.in"
+#line 863 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4030,		T_BOO,	0,"@@i_quadmath@@"},
-#line 746 "ext/Config/Config_xs.in"
+#line 754 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4031,		T_STR,	0,"@@freetype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1076 "ext/Config/Config_xs.in"
+#line 1084 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4035,		T_STR,	0,"@@randseedtype@@"},
-#line 452 "ext/Config/Config_xs.in"
+#line 460 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4036,		T_BOO,	0,"@@d_mbtowc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1159 "ext/Config/Config_xs.in"
+#line 1167 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4047,		T_STR,	0,"@@socksizetype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 873 "ext/Config/Config_xs.in"
+#line 881 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4061,		T_BOO,	0,"@@i_syslog@@"},
       {-1, -1, 0, NULL},
-#line 1078 "ext/Config/Config_xs.in"
+#line 1086 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4063,		T_INT,	0,"@@rd_nodata@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 406 "ext/Config/Config_xs.in"
+#line 414 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4078,		T_BOO,	0,"@@d_isblank@@"},
       {-1, -1, 0, NULL},
-#line 122 "ext/Config/Config_xs.in"
+#line 130 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4080,		T_STR,	0,"@@cccdlflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 767 "ext/Config/Config_xs.in"
+#line 775 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4083,	T_INT,	0,"@@getpwent_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 940 "ext/Config/Config_xs.in"
+#line 948 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4096,	T_STR,	0,"@@installvendorscript@@"},
       {-1, -1, 0, NULL},
-#line 519 "ext/Config/Config_xs.in"
+#line 527 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4098,		T_BOO,	0,"@@d_pwexpire@@"},
-#line 233 "ext/Config/Config_xs.in"
+#line 241 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4099,		T_BOO,	0,"@@d_chown@@"},
       {-1, -1, 0, NULL},
-#line 1104 "ext/Config/Config_xs.in"
+#line 1112 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4101,		T_STR,	0,"@@sched_yield@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 517 "ext/Config/Config_xs.in"
+#line 525 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4108,		T_BOO,	0,"@@d_pwclass@@"},
       {-1, -1, 0, NULL},
-#line 952 "ext/Config/Config_xs.in"
+#line 960 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4110,	T_STR,	0,"@@ldflags_nolargefiles@@"},
-#line 1153 "ext/Config/Config_xs.in"
+#line 1161 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4111,		T_STR,	0,"@@sizetype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 904 "ext/Config/Config_xs.in"
+#line 912 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4115,		T_STR,	0,"@@i_varhdr@@"},
-#line 1007 "ext/Config/Config_xs.in"
+#line 1015 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4116,		T_STR,	0,"@@mmaptype@@"},
-#line 938 "ext/Config/Config_xs.in"
+#line 946 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4117,	T_STR,	0,"@@installvendorman1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 455 "ext/Config/Config_xs.in"
+#line 463 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4121,		T_BOO,	0,"@@d_memcpy@@"},
-#line 939 "ext/Config/Config_xs.in"
+#line 947 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4122,	T_STR,	0,"@@installvendorman3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 745 "ext/Config/Config_xs.in"
+#line 753 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4126,		T_STR,	0,"@@fpostype@@"},
-#line 139 "ext/Config/Config_xs.in"
+#line 147 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4127,			T_STR,	0,"@@chown@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1205 "ext/Config/Config_xs.in"
+#line 1213 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4143,	T_INT,	0,"@@ttyname_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 456 "ext/Config/Config_xs.in"
+#line 464 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4146,		T_BOO,	0,"@@d_memmove@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 344 "ext/Config/Config_xs.in"
+#line 352 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4150,	T_BOO,	0,"@@d_gethostprotos@@"},
-#line 439 "ext/Config/Config_xs.in"
+#line 447 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4151,		T_BOO,	0,"@@d_longdbl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1167 "ext/Config/Config_xs.in"
+#line 1175 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4163,		T_INT,	0,"@@st_ino_sign@@"},
-#line 343 "ext/Config/Config_xs.in"
+#line 351 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4164,		T_BOO,	0,"@@d_gethostent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1257 "ext/Config/Config_xs.in"
+#line 1265 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4176,		T_STR,	0,"@@uvoformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 700 "ext/Config/Config_xs.in"
+#line 708 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4182,		T_BOO,	0,"@@d_wctomb@@"},
       {-1, -1, 0, NULL},
-#line 752 "ext/Config/Config_xs.in"
+#line 760 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4184,		T_STR,	0,"@@gccosandvers@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 739 "ext/Config/Config_xs.in"
+#line 747 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4210,		T_BOO,	0,"@@fflushNULL@@"},
       {-1, -1, 0, NULL},
-#line 753 "ext/Config/Config_xs.in"
+#line 761 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4212,		T_STR,	0,"@@gccversion@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1233 "ext/Config/Config_xs.in"
+#line 1241 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4228,		T_BOO,	0,"@@uselargefiles@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 993 "ext/Config/Config_xs.in"
+#line 1001 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4237,		T_STR,	0,"@@make_set_make@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1273 "ext/Config/Config_xs.in"
+#line 1281 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4245,		T_STR,	0,"@@vendorlibexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 451 "ext/Config/Config_xs.in"
+#line 459 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4249,		T_BOO,	0,"@@d_mbstowcs@@"},
       {-1, -1, 0, NULL},
-#line 532 "ext/Config/Config_xs.in"
+#line 540 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4251,		T_BOO,	0,"@@d_recvmsg@@"},
       {-1, -1, 0, NULL},
-#line 759 "ext/Config/Config_xs.in"
+#line 767 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4253,	T_INT,	0,"@@gethostent_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 803 "ext/Config/Config_xs.in"
+#line 811 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4255,		T_STR,	0,"@@html1dir@@"},
       {-1, -1, 0, NULL},
-#line 197 "ext/Config/Config_xs.in"
+#line 205 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4257,		T_BOO,	0,"@@d__fwalk@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 805 "ext/Config/Config_xs.in"
+#line 813 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4260,		T_STR,	0,"@@html3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 868 "ext/Config/Config_xs.in"
+#line 876 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4263,		T_BOO,	0,"@@i_sysdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 935 "ext/Config/Config_xs.in"
+#line 943 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4273,	T_STR,	0,"@@installvendorhtml1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 936 "ext/Config/Config_xs.in"
+#line 944 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4278,	T_STR,	0,"@@installvendorhtml3dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 590 "ext/Config/Config_xs.in"
+#line 598 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4286,		T_BOO,	0,"@@d_setvbuf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 100 "ext/Config/Config_xs.in"
+#line 108 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4290,		T_INT,	0,"@@api_version@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 657 "ext/Config/Config_xs.in"
+#line 665 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4296,		T_BOO,	0,"@@d_tcgetpgrp@@"},
-#line 1253 "ext/Config/Config_xs.in"
+#line 1261 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4297,		T_STR,	0,"@@usevfork@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 478 "ext/Config/Config_xs.in"
+#line 486 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4300,		T_BOO,	0,"@@d_msghdr_s@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1231 "ext/Config/Config_xs.in"
+#line 1239 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4303,		T_BOO,	0,"@@useithreads@@"},
       {-1, -1, 0, NULL},
-#line 792 "ext/Config/Config_xs.in"
+#line 800 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4305,		T_STR,	0,"@@groupcat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1130 "ext/Config/Config_xs.in"
+#line 1138 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4309,		T_STR,	0,"@@sig_num_init@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 404 "ext/Config/Config_xs.in"
+#line 412 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4315,	T_BOO,	0,"@@d_ipv6_mreq_source@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 606 "ext/Config/Config_xs.in"
+#line 614 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4318,		T_BOO,	0,"@@d_sockatmark@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 890 "ext/Config/Config_xs.in"
+#line 898 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4323,		T_BOO,	0,"@@i_systypes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 885 "ext/Config/Config_xs.in"
+#line 893 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4329,		T_BOO,	0,"@@i_sysstatfs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 653 "ext/Config/Config_xs.in"
+#line 661 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4337,		T_BOO,	0,"@@d_sysconf@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 781 "ext/Config/Config_xs.in"
+#line 789 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4340,		T_STR,	0,"@@git_commit_id@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 117 "ext/Config/Config_xs.in"
+#line 125 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4344,		T_INT,	0,"@@byteorder@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 363 "ext/Config/Config_xs.in"
+#line 371 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4359,		T_BOO,	0,"@@d_getpgrp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 505 "ext/Config/Config_xs.in"
+#line 513 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4389,		T_BOO,	0,"@@d_portable@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 945 "ext/Config/Config_xs.in"
+#line 953 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4401,			T_STR,	0,"@@ivtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1136 "ext/Config/Config_xs.in"
+#line 1144 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4405,		T_STR,	0,"@@sitebinexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 782 "ext/Config/Config_xs.in"
+#line 790 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4416,	T_STR,	0,"@@git_commit_id_title@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 130 "ext/Config/Config_xs.in"
+#line 138 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4428,		T_STR,	0,"@@ccversion@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1122 "ext/Config/Config_xs.in"
+#line 1130 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4439,		T_STR,	0,"@@shmattype@@"},
       {-1, -1, 0, NULL},
-#line 1126 "ext/Config/Config_xs.in"
+#line 1134 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4441,		T_INT,	0,"@@sig_count@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 581 "ext/Config/Config_xs.in"
+#line 589 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4447,		T_BOO,	0,"@@d_setregid@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1025 "ext/Config/Config_xs.in"
+#line 1033 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4456,		T_STR,	0,"@@nonxs_ext@@"},
       {-1, -1, 0, NULL},
-#line 997 "ext/Config/Config_xs.in"
+#line 1005 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4458,		T_STR,	0,"@@malloctype@@"},
       {-1, -1, 0, NULL},
-#line 907 "ext/Config/Config_xs.in"
+#line 915 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4460,	T_STR,	0,"@@inc_version_list@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 549 "ext/Config/Config_xs.in"
+#line 557 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4482,		T_BOO,	0,"@@d_scm_rights@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1134 "ext/Config/Config_xs.in"
+#line 1142 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4487,		T_STR,	0,"@@sitearchexp@@"},
-#line 607 "ext/Config/Config_xs.in"
+#line 615 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4488,	T_BOO,	0,"@@d_sockatmarkproto@@"},
       {-1, -1, 0, NULL},
-#line 908 "ext/Config/Config_xs.in"
+#line 916 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4490,	T_STR,	0,"@@inc_version_list_init@@"},
-#line 1072 "ext/Config/Config_xs.in"
+#line 1080 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4491,		T_STR,	0,"@@quadtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 125 "ext/Config/Config_xs.in"
+#line 133 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4495,	T_STR,	0,"@@ccflags_nolargefiles@@"},
-#line 1037 "ext/Config/Config_xs.in"
+#line 1045 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4496,			T_STR,	0,"@@nvtype@@"},
-#line 1224 "ext/Config/Config_xs.in"
+#line 1232 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4497,		T_BOO,	0,"@@usecbacktrace@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 780 "ext/Config/Config_xs.in"
+#line 788 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4507,	T_STR,	0,"@@git_commit_date@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 685 "ext/Config/Config_xs.in"
+#line 693 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4510,		T_BOO,	0,"@@d_vendorlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 514 "ext/Config/Config_xs.in"
+#line 522 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4518,		T_BOO,	0,"@@d_ptrdiff_t@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1232 "ext/Config/Config_xs.in"
+#line 1240 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4521,	T_BOO,	0,"@@usekernprocpathname@@"},
-#line 382 "ext/Config/Config_xs.in"
+#line 390 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4522,	T_BOO,	0,"@@d_getservprotos@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1019 "ext/Config/Config_xs.in"
+#line 1027 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4525,	T_STR,	0,"@@netdb_host_type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 543 "ext/Config/Config_xs.in"
+#line 551 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4533,		T_BOO,	0,"@@d_safemcpy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 381 "ext/Config/Config_xs.in"
+#line 389 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4536,		T_BOO,	0,"@@d_getservent_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1182 "ext/Config/Config_xs.in"
+#line 1190 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4539,		T_INT,	0,"@@subversion@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 966 "ext/Config/Config_xs.in"
+#line 974 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4545,		T_STR,	0,"@@libspath@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 477 "ext/Config/Config_xs.in"
+#line 485 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4548,		T_BOO,	0,"@@d_msgget@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1260 "ext/Config/Config_xs.in"
+#line 1268 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4556,		T_STR,	0,"@@uvuformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 924 "ext/Config/Config_xs.in"
+#line 932 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4573,		T_STR,	0,"@@installsitebin@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 983 "ext/Config/Config_xs.in"
+#line 991 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4577,		T_INT,	0,"@@longlongsize@@"},
-#line 920 "ext/Config/Config_xs.in"
+#line 928 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4578,	T_STR,	0,"@@installprefixexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 364 "ext/Config/Config_xs.in"
+#line 372 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4590,		T_BOO,	0,"@@d_getpgrp2@@"},
-#line 950 "ext/Config/Config_xs.in"
+#line 958 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4591,		T_STR,	0,"@@lddlflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 773 "ext/Config/Config_xs.in"
+#line 781 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4598,	T_INT,	0,"@@getspnam_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 515 "ext/Config/Config_xs.in"
+#line 523 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4604,		T_BOO,	0,"@@d_pwage@@"},
-#line 707 "ext/Config/Config_xs.in"
+#line 715 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4605,	T_INT,	0,"@@db_version_minor@@"},
       {-1, -1, 0, NULL},
-#line 474 "ext/Config/Config_xs.in"
+#line 482 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4607,		T_BOO,	0,"@@d_msg_peek@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1284 "ext/Config/Config_xs.in"
+#line 1292 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4616,		T_BOO,	0,"@@versiononly@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 925 "ext/Config/Config_xs.in"
+#line 933 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4621,	T_STR,	0,"@@installsitehtml1dir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 926 "ext/Config/Config_xs.in"
+#line 934 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4626,	T_STR,	0,"@@installsitehtml3dir@@"},
-#line 832 "ext/Config/Config_xs.in"
+#line 840 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4627,		T_BOO,	0,"@@i_gdbmndbm@@"},
       {-1, -1, 0, NULL},
-#line 289 "ext/Config/Config_xs.in"
+#line 297 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4629,		T_BOO,	0,"@@d_fchown@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 542 "ext/Config/Config_xs.in"
+#line 550 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4643,		T_BOO,	0,"@@d_safebcpy@@"},
-#line 226 "ext/Config/Config_xs.in"
+#line 234 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4644,	T_BOO,	0,"@@d_builtin_expect@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 914 "ext/Config/Config_xs.in"
+#line 922 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4654,		T_STR,	0,"@@installbin@@"},
       {-1, -1, 0, NULL},
-#line 418 "ext/Config/Config_xs.in"
+#line 426 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4656,	T_BOO,	0,"@@d_lc_monetary_2008@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1189 "ext/Config/Config_xs.in"
+#line 1197 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4671,		T_STR,	0,"@@targetenv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 856 "ext/Config/Config_xs.in"
+#line 864 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4675,		T_BOO,	0,"@@i_rpcsvcdbm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 135 "ext/Config/Config_xs.in"
+#line 143 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4680,		T_INT,	0,"@@charbits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1033 "ext/Config/Config_xs.in"
+#line 1041 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4701,		T_STR,	0,"@@nvfformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1067 "ext/Config/Config_xs.in"
+#line 1075 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4710,		T_STR,	0,"@@privlibexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 241 "ext/Config/Config_xs.in"
+#line 249 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4713,		T_BOO,	0,"@@d_copysign@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 923 "ext/Config/Config_xs.in"
+#line 931 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4722,	T_STR,	0,"@@installsitearch@@"},
-#line 988 "ext/Config/Config_xs.in"
+#line 996 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4723,		T_INT,	0,"@@lseeksize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 733 "ext/Config/Config_xs.in"
+#line 741 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4727,		T_STR,	0,"@@eunicefix@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 891 "ext/Config/Config_xs.in"
+#line 899 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4743,		T_BOO,	0,"@@i_sysuio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1015 "ext/Config/Config_xs.in"
+#line 1023 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4750,		T_STR,	0,"@@myuname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 242 "ext/Config/Config_xs.in"
+#line 250 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4754,		T_BOO,	0,"@@d_copysignl@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1125 "ext/Config/Config_xs.in"
+#line 1133 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4757,		T_STR,	0,"@@shsharp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 715 "ext/Config/Config_xs.in"
+#line 723 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4768,		T_INT,	0,"@@doublemantbits@@"},
       {-1, -1, 0, NULL},
-#line 706 "ext/Config/Config_xs.in"
+#line 714 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4770,	T_INT,	0,"@@db_version_major@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1020 "ext/Config/Config_xs.in"
+#line 1028 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4775,	T_STR,	0,"@@netdb_name_type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 701 "ext/Config/Config_xs.in"
+#line 709 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4797,		T_BOO,	0,"@@d_writev@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 392 "ext/Config/Config_xs.in"
+#line 400 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4805,		T_BOO,	0,"@@d_hypot@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 942 "ext/Config/Config_xs.in"
+#line 950 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4814,		T_STR,	0,"@@issymlink@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 376 "ext/Config/Config_xs.in"
+#line 384 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4820,		T_BOO,	0,"@@d_getsbyname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 650 "ext/Config/Config_xs.in"
+#line 658 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4824,		T_BOO,	0,"@@d_symlink@@"},
       {-1, -1, 0, NULL},
-#line 1259 "ext/Config/Config_xs.in"
+#line 1267 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4826,			T_STR,	0,"@@uvtype@@"},
-#line 383 "ext/Config/Config_xs.in"
+#line 391 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4827,		T_BOO,	0,"@@d_getspnam@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 488 "ext/Config/Config_xs.in"
+#line 496 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4834,		T_BOO,	0,"@@d_nextafter@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 317 "ext/Config/Config_xs.in"
+#line 325 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4840,		T_BOO,	0,"@@d_fs_data_s@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 170 "ext/Config/Config_xs.in"
+#line 178 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4846,		T_INT,	0,"@@cpp_stuff@@"},
       {-1, -1, 0, NULL},
-#line 596 "ext/Config/Config_xs.in"
+#line 604 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4848,		T_BOO,	0,"@@d_shmget@@"},
-#line 384 "ext/Config/Config_xs.in"
+#line 392 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4849,		T_BOO,	0,"@@d_getspnam_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 359 "ext/Config/Config_xs.in"
+#line 367 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4865,		T_BOO,	0,"@@d_getpbyname@@"},
-#line 487 "ext/Config/Config_xs.in"
+#line 495 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4866,		T_BOO,	0,"@@d_nearbyint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 116 "ext/Config/Config_xs.in"
+#line 124 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4875,			T_STR,	0,"@@byacc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 501 "ext/Config/Config_xs.in"
+#line 509 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4881,	T_BOO,	0,"@@d_perl_otherlibdirs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 502 "ext/Config/Config_xs.in"
+#line 510 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4893,		T_BOO,	0,"@@d_phostname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 385 "ext/Config/Config_xs.in"
+#line 393 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4898,		T_BOO,	0,"@@d_gettimeod@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 119 "ext/Config/Config_xs.in"
+#line 127 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4901,		T_INT,	0,"@@castflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 352 "ext/Config/Config_xs.in"
+#line 360 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4925,		T_BOO,	0,"@@d_getnbyname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 785 "ext/Config/Config_xs.in"
+#line 793 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4928,	T_INT,	0,"@@git_uncommitted_changes@@"},
       {-1, -1, 0, NULL},
-#line 777 "ext/Config/Config_xs.in"
+#line 785 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4930,		T_STR,	0,"@@gidtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 994 "ext/Config/Config_xs.in"
+#line 1002 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4933,		T_STR,	0,"@@malloc_cflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 232 "ext/Config/Config_xs.in"
+#line 240 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4937,		T_BOO,	0,"@@d_charvspr@@"},
       {-1, -1, 0, NULL},
-#line 651 "ext/Config/Config_xs.in"
+#line 659 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4939,		T_BOO,	0,"@@d_syscall@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 287 "ext/Config/Config_xs.in"
+#line 295 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4950,		T_BOO,	0,"@@d_fchdir@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 104 "ext/Config/Config_xs.in"
+#line 112 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4958,		T_STR,	0,"@@archlibexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1251 "ext/Config/Config_xs.in"
+#line 1259 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4973,	T_BOO,	0,"@@usevendorprefix@@"},
-#line 1021 "ext/Config/Config_xs.in"
+#line 1029 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4974,		T_STR,	0,"@@netdb_net_type@@"},
       {-1, -1, 0, NULL},
-#line 123 "ext/Config/Config_xs.in"
+#line 131 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4976,		T_STR,	0,"@@ccdlflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 967 "ext/Config/Config_xs.in"
+#line 975 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4984,		T_STR,	0,"@@libswanted@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 339 "ext/Config/Config_xs.in"
+#line 347 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str4999,		T_BOO,	0,"@@d_gethent@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1234 "ext/Config/Config_xs.in"
+#line 1242 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5005,		T_BOO,	0,"@@uselongdouble@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1248 "ext/Config/Config_xs.in"
+#line 1256 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5028,	T_BOO,	0,"@@usesitecustomize@@"},
       {-1, -1, 0, NULL},
-#line 377 "ext/Config/Config_xs.in"
+#line 385 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5030,		T_BOO,	0,"@@d_getsbyport@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 523 "ext/Config/Config_xs.in"
+#line 531 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5034,		T_BOO,	0,"@@d_qgcvt@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 954 "ext/Config/Config_xs.in"
+#line 962 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5039,		T_STR,	0,"@@ldlibpthname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1014 "ext/Config/Config_xs.in"
+#line 1022 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5043,		T_STR,	0,"@@myhostname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 965 "ext/Config/Config_xs.in"
+#line 973 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5048,		T_STR,	0,"@@libsfound@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 308 "ext/Config/Config_xs.in"
+#line 316 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5051,		T_BOO,	0,"@@d_fp_classify@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 165 "ext/Config/Config_xs.in"
+#line 173 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5056,		T_STR,	0,"@@config_args@@"},
       {-1, -1, 0, NULL},
-#line 762 "ext/Config/Config_xs.in"
+#line 770 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5058,	T_INT,	0,"@@getnetbyname_r_proto@@"},
-#line 652 "ext/Config/Config_xs.in"
+#line 660 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5059,		T_BOO,	0,"@@d_syscallproto@@"},
       {-1, -1, 0, NULL},
-#line 163 "ext/Config/Config_xs.in"
+#line 171 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5061,		T_STR,	0,"@@config_arg9@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 144 "ext/Config/Config_xs.in"
+#line 152 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5066,		T_STR,	0,"@@config_arg1@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 157 "ext/Config/Config_xs.in"
+#line 165 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5071,		T_STR,	0,"@@config_arg3@@"},
-#line 154 "ext/Config/Config_xs.in"
+#line 162 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5072,		T_STR,	0,"@@config_arg19@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 146 "ext/Config/Config_xs.in"
+#line 154 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5077,		T_STR,	0,"@@config_arg11@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 148 "ext/Config/Config_xs.in"
+#line 156 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5082,		T_STR,	0,"@@config_arg13@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 704 "ext/Config/Config_xs.in"
+#line 712 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5088,		T_STR,	0,"@@db_hashtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 522 "ext/Config/Config_xs.in"
+#line 530 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5093,		T_BOO,	0,"@@d_pwquota@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 143 "ext/Config/Config_xs.in"
+#line 151 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5096,		T_STR,	0,"@@config_arg0@@"},
       {-1, -1, 0, NULL},
-#line 511 "ext/Config/Config_xs.in"
+#line 519 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5098,	T_BOO,	0,"@@d_pthread_atfork@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 160 "ext/Config/Config_xs.in"
+#line 168 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5101,		T_STR,	0,"@@config_arg6@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 145 "ext/Config/Config_xs.in"
+#line 153 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5107,		T_STR,	0,"@@config_arg10@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 159 "ext/Config/Config_xs.in"
+#line 167 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5111,		T_STR,	0,"@@config_arg5@@"},
-#line 151 "ext/Config/Config_xs.in"
+#line 159 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5112,		T_STR,	0,"@@config_arg16@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 162 "ext/Config/Config_xs.in"
+#line 170 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5116,		T_STR,	0,"@@config_arg8@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 158 "ext/Config/Config_xs.in"
+#line 166 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5121,		T_STR,	0,"@@config_arg4@@"},
-#line 150 "ext/Config/Config_xs.in"
+#line 158 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5122,		T_STR,	0,"@@config_arg15@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 153 "ext/Config/Config_xs.in"
+#line 161 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5127,		T_STR,	0,"@@config_arg18@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 149 "ext/Config/Config_xs.in"
+#line 157 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5132,		T_STR,	0,"@@config_arg14@@"},
-#line 1237 "ext/Config/Config_xs.in"
+#line 1245 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5133,	T_BOO,	0,"@@usemultiplicity@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 321 "ext/Config/Config_xs.in"
+#line 329 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5157,		T_BOO,	0,"@@d_fstatvfs@@"},
-#line 225 "ext/Config/Config_xs.in"
+#line 233 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5158,	T_BOO,	0,"@@d_builtin_choose_expr@@"},
       {-1, -1, 0, NULL},
-#line 906 "ext/Config/Config_xs.in"
+#line 914 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5160,	T_STR,	0,"@@ignore_versioned_solibs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1246 "ext/Config/Config_xs.in"
+#line 1254 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5166,	T_BOO,	0,"@@userelocatableinc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 107 "ext/Config/Config_xs.in"
+#line 115 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5187,		T_STR,	0,"@@archobjs@@"},
       {-1, -1, 0, NULL},
-#line 129 "ext/Config/Config_xs.in"
+#line 137 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5189,		T_STR,	0,"@@ccsymbols@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1148 "ext/Config/Config_xs.in"
+#line 1156 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5193,		T_STR,	0,"@@siteprefix@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1252 "ext/Config/Config_xs.in"
+#line 1260 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5202,	T_BOO,	0,"@@useversionedarchname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 699 "ext/Config/Config_xs.in"
+#line 707 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5212,		T_BOO,	0,"@@d_wcsxfrm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 161 "ext/Config/Config_xs.in"
+#line 169 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5221,		T_STR,	0,"@@config_arg7@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 152 "ext/Config/Config_xs.in"
+#line 160 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5232,		T_STR,	0,"@@config_arg17@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 491 "ext/Config/Config_xs.in"
+#line 499 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5250,		T_BOO,	0,"@@d_nl_langinfo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 164 "ext/Config/Config_xs.in"
+#line 172 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5271,		T_INT,	0,"@@config_argc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 155 "ext/Config/Config_xs.in"
+#line 163 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5286,		T_STR,	0,"@@config_arg2@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 147 "ext/Config/Config_xs.in"
+#line 155 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5297,		T_STR,	0,"@@config_arg12@@"},
       {-1, -1, 0, NULL},
-#line 223 "ext/Config/Config_xs.in"
+#line 231 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5299,		T_BOO,	0,"@@d_bsdsetpgrp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 709 "ext/Config/Config_xs.in"
+#line 717 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5303,		T_STR,	0,"@@direntrytype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 786 "ext/Config/Config_xs.in"
+#line 794 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5307,		T_STR,	0,"@@git_unpushed@@"},
-#line 824 "ext/Config/Config_xs.in"
+#line 832 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5308,		T_BOO,	0,"@@i_execinfo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 346 "ext/Config/Config_xs.in"
+#line 354 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5322,		T_BOO,	0,"@@d_getlogin@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 156 "ext/Config/Config_xs.in"
+#line 164 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5327,		T_STR,	0,"@@config_arg20@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 347 "ext/Config/Config_xs.in"
+#line 355 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5344,		T_BOO,	0,"@@d_getlogin_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1013 "ext/Config/Config_xs.in"
+#line 1021 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5348,		T_STR,	0,"@@mydomain@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1059 "ext/Config/Config_xs.in"
+#line 1067 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5356,		T_STR,	0,"@@phostname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1012 "ext/Config/Config_xs.in"
+#line 1020 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5373,		T_STR,	0,"@@myarchname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 447 "ext/Config/Config_xs.in"
+#line 455 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5383,		T_BOO,	0,"@@d_madvise@@"},
-#line 1176 "ext/Config/Config_xs.in"
+#line 1184 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5384,		T_STR,	0,"@@stdio_filbuf@@"},
-#line 721 "ext/Config/Config_xs.in"
+#line 729 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5385,		T_STR,	0,"@@dynamic_ext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1034 "ext/Config/Config_xs.in"
+#line 1042 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5396,		T_STR,	0,"@@nvgformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1027 "ext/Config/Config_xs.in"
+#line 1035 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5399,		T_STR,	0,"@@nvEUformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1029 "ext/Config/Config_xs.in"
+#line 1037 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5404,		T_STR,	0,"@@nvGUformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 132 "ext/Config/Config_xs.in"
+#line 140 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5410,			T_STR,	0,"@@cf_by@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1028 "ext/Config/Config_xs.in"
+#line 1036 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5424,		T_STR,	0,"@@nvFUformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 354 "ext/Config/Config_xs.in"
+#line 362 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5434,	T_BOO,	0,"@@d_getnetbyaddr_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 375 "ext/Config/Config_xs.in"
+#line 383 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5445,		T_BOO,	0,"@@d_getpwuid_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 513 "ext/Config/Config_xs.in"
+#line 521 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5453,	T_BOO,	0,"@@d_pthread_yield@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1065 "ext/Config/Config_xs.in"
+#line 1073 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5471,		T_STR,	0,"@@prefixexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1018 "ext/Config/Config_xs.in"
+#line 1026 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5505,	T_STR,	0,"@@netdb_hlen_type@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1261 "ext/Config/Config_xs.in"
+#line 1269 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5532,		T_STR,	0,"@@uvxformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 764 "ext/Config/Config_xs.in"
+#line 772 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5535,	T_INT,	0,"@@getprotobyname_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 374 "ext/Config/Config_xs.in"
+#line 382 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5545,		T_BOO,	0,"@@d_getpwnam_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 887 "ext/Config/Config_xs.in"
+#line 895 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5564,		T_BOO,	0,"@@i_systime@@"},
-#line 889 "ext/Config/Config_xs.in"
+#line 897 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5565,		T_BOO,	0,"@@i_systimes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 836 "ext/Config/Config_xs.in"
+#line 844 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5607,		T_BOO,	0,"@@i_langinfo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1236 "ext/Config/Config_xs.in"
+#line 1244 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5625,		T_BOO,	0,"@@usemorebits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 486 "ext/Config/Config_xs.in"
+#line 494 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5656,	T_BOO,	0,"@@d_ndbm_h_uses_prototypes@@"},
-#line 1187 "ext/Config/Config_xs.in"
+#line 1195 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5657,		T_STR,	0,"@@targetarch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 751 "ext/Config/Config_xs.in"
+#line 759 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5677,	T_STR,	0,"@@gccansipedantic@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 620 "ext/Config/Config_xs.in"
+#line 628 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5681,	T_BOO,	0,"@@d_statfs_f_flags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 793 "ext/Config/Config_xs.in"
+#line 801 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5688,		T_STR,	0,"@@groupstype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 335 "ext/Config/Config_xs.in"
+#line 343 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5694,		T_BOO,	0,"@@d_getgrnam_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1039 "ext/Config/Config_xs.in"
+#line 1047 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5732,		T_STR,	0,"@@obj_ext@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 671 "ext/Config/Config_xs.in"
+#line 679 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5741,		T_BOO,	0,"@@d_ttyname_r@@"},
-#line 765 "ext/Config/Config_xs.in"
+#line 773 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5742,	T_INT,	0,"@@getprotobynumber_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 1256 "ext/Config/Config_xs.in"
+#line 1264 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5744,		T_STR,	0,"@@uvXUformat@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 937 "ext/Config/Config_xs.in"
+#line 945 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5755,	T_STR,	0,"@@installvendorlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1123 "ext/Config/Config_xs.in"
+#line 1131 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5761,		T_INT,	0,"@@shortsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 95 "ext/Config/Config_xs.in"
+#line 103 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5777,		T_INT,	0,"@@alignbytes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 760 "ext/Config/Config_xs.in"
+#line 768 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5818,	T_INT,	0,"@@getlogin_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 218 "ext/Config/Config_xs.in"
+#line 226 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5827,		T_BOO,	0,"@@d_backtrace@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1045 "ext/Config/Config_xs.in"
+#line 1053 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5851,		T_STR,	0,"@@otherlibdirs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -5965,105 +5973,105 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 420 "ext/Config/Config_xs.in"
+#line 428 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5899,		T_BOO,	0,"@@d_ldbl_dig@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 355 "ext/Config/Config_xs.in"
+#line 363 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5919,	T_BOO,	0,"@@d_getnetbyname_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 933 "ext/Config/Config_xs.in"
+#line 941 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5944,	T_STR,	0,"@@installvendorarch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 894 "ext/Config/Config_xs.in"
+#line 902 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str5968,		T_BOO,	0,"@@i_sysvfs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 946 "ext/Config/Config_xs.in"
+#line 954 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6011,	T_STR,	0,"@@known_extensions@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1263 "ext/Config/Config_xs.in"
+#line 1271 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6014,		T_STR,	0,"@@vendorarch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 101 "ext/Config/Config_xs.in"
+#line 109 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6026,	T_STR,	0,"@@api_versionstring@@"},
       {-1, -1, 0, NULL},
-#line 388 "ext/Config/Config_xs.in"
+#line 396 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6028,		T_BOO,	0,"@@d_gnulibc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 742 "ext/Config/Config_xs.in"
+#line 750 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6032,		T_STR,	0,"@@firstmakefile@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1244 "ext/Config/Config_xs.in"
+#line 1252 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6048,		T_BOO,	0,"@@usequadmath@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 350 "ext/Config/Config_xs.in"
+#line 358 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6060,		T_BOO,	0,"@@d_getnameinfo@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1053 "ext/Config/Config_xs.in"
+#line 1061 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6084,	T_STR,	0,"@@perl_patchlevel@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 215 "ext/Config/Config_xs.in"
+#line 223 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6112,	T_BOO,	0,"@@d_attribute_pure@@"},
       {-1, -1, 0, NULL},
-#line 869 "ext/Config/Config_xs.in"
+#line 877 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6114,		T_BOO,	0,"@@i_sysfile@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 790 "ext/Config/Config_xs.in"
+#line 798 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6119,	T_STR,	0,"@@gnulibc_version@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 493 "ext/Config/Config_xs.in"
+#line 501 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6159,	T_BOO,	0,"@@d_nv_zero_is_allbits_zero@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 756 "ext/Config/Config_xs.in"
+#line 764 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6163,	T_INT,	0,"@@getgrnam_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1278 "ext/Config/Config_xs.in"
+#line 1286 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6180,		T_STR,	0,"@@vendorprefix@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1238 "ext/Config/Config_xs.in"
+#line 1246 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6191,		T_STR,	0,"@@usemymalloc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 358 "ext/Config/Config_xs.in"
+#line 366 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6217,		T_BOO,	0,"@@d_getpagsz@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1279 "ext/Config/Config_xs.in"
+#line 1287 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6228,	T_STR,	0,"@@vendorprefixexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 683 "ext/Config/Config_xs.in"
+#line 691 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6236,		T_BOO,	0,"@@d_vendorarch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 351 "ext/Config/Config_xs.in"
+#line 359 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6247,		T_BOO,	0,"@@d_getnbyaddr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 567 "ext/Config/Config_xs.in"
+#line 575 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6251,		T_BOO,	0,"@@d_setlinebuf@@"},
-#line 1049 "ext/Config/Config_xs.in"
+#line 1057 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6252,		T_INT,	0,"@@patchlevel@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6073,62 +6081,62 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 886 "ext/Config/Config_xs.in"
+#line 894 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6322,		T_BOO,	0,"@@i_sysstatvfs@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 210 "ext/Config/Config_xs.in"
+#line 218 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6338,	T_BOO,	0,"@@d_attribute_deprecated@@"},
       {-1, -1, 0, NULL},
-#line 769 "ext/Config/Config_xs.in"
+#line 777 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6340,	T_INT,	0,"@@getpwuid_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 425 "ext/Config/Config_xs.in"
+#line 433 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6345,	T_BOO,	0,"@@d_libname_unique@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1223 "ext/Config/Config_xs.in"
+#line 1231 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6372,		T_BOO,	0,"@@use64bitint@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 761 "ext/Config/Config_xs.in"
+#line 769 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6380,	T_INT,	0,"@@getnetbyaddr_r_proto@@"},
       {-1, -1, 0, NULL},
-#line 1222 "ext/Config/Config_xs.in"
+#line 1230 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6382,		T_BOO,	0,"@@use64bitall@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 300 "ext/Config/Config_xs.in"
+#line 308 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6418,		T_BOO,	0,"@@d_flexfnam@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 784 "ext/Config/Config_xs.in"
+#line 792 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6429,	T_STR,	0,"@@git_remote_branch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 312 "ext/Config/Config_xs.in"
+#line 320 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6437,		T_BOO,	0,"@@d_fpclassify@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 768 "ext/Config/Config_xs.in"
+#line 776 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6440,	T_INT,	0,"@@getpwnam_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 888 "ext/Config/Config_xs.in"
+#line 896 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6462,		T_BOO,	0,"@@i_systimek@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 179 "ext/Config/Config_xs.in"
+#line 187 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6470,		T_STR,	0,"@@cryptlib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 708 "ext/Config/Config_xs.in"
+#line 716 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6485,	T_INT,	0,"@@db_version_patch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1017 "ext/Config/Config_xs.in"
+#line 1025 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6514,		T_BOO,	0,"@@need_va_copy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6136,69 +6144,69 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 740 "ext/Config/Config_xs.in"
+#line 748 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6566,		T_BOO,	0,"@@fflushall@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 771 "ext/Config/Config_xs.in"
+#line 779 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6580,	T_INT,	0,"@@getservbyport_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 895 "ext/Config/Config_xs.in"
+#line 903 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6586,		T_BOO,	0,"@@i_syswait@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 327 "ext/Config/Config_xs.in"
+#line 335 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6590,	T_BOO,	0,"@@d_gdbmndbm_h_uses_prototypes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 475 "ext/Config/Config_xs.in"
+#line 483 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6600,		T_BOO,	0,"@@d_msg_proxy@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 214 "ext/Config/Config_xs.in"
+#line 222 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6621,	T_BOO,	0,"@@d_attribute_noreturn@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 804 "ext/Config/Config_xs.in"
+#line 812 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6624,		T_STR,	0,"@@html1direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 806 "ext/Config/Config_xs.in"
+#line 814 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6629,		T_STR,	0,"@@html3direxp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 492 "ext/Config/Config_xs.in"
+#line 500 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6643,	T_BOO,	0,"@@d_nv_preserves_uv@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1149 "ext/Config/Config_xs.in"
+#line 1157 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6652,		T_STR,	0,"@@siteprefixexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 878 "ext/Config/Config_xs.in"
+#line 886 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6667,		T_BOO,	0,"@@i_sysparam@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 962 "ext/Config/Config_xs.in"
+#line 970 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6686,	T_STR,	0,"@@libs_nolargefiles@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 338 "ext/Config/Config_xs.in"
+#line 346 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6725,		T_BOO,	0,"@@d_gethbyname@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 831 "ext/Config/Config_xs.in"
+#line 839 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6750,		T_BOO,	0,"@@i_gdbm_ndbm@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 334 "ext/Config/Config_xs.in"
+#line 342 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6764,		T_BOO,	0,"@@d_getgrgid_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 212 "ext/Config/Config_xs.in"
+#line 220 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6804,	T_BOO,	0,"@@d_attribute_malloc@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6206,7 +6214,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 213 "ext/Config/Config_xs.in"
+#line 221 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6855,	T_BOO,	0,"@@d_attribute_nonnull@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6214,47 +6222,47 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 222 "ext/Config/Config_xs.in"
+#line 230 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6904,		T_BOO,	0,"@@d_bsdgetpgrp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 216 "ext/Config/Config_xs.in"
+#line 224 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6939,	T_BOO,	0,"@@d_attribute_unused@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 968 "ext/Config/Config_xs.in"
+#line 976 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6957,	T_STR,	0,"@@libswanted_nolargefiles@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1247 "ext/Config/Config_xs.in"
+#line 1255 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str6964,		T_STR,	0,"@@useshrplib@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 982 "ext/Config/Config_xs.in"
+#line 990 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7005,		T_INT,	0,"@@longdblsize@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 797 "ext/Config/Config_xs.in"
+#line 805 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7021,		T_STR,	0,"@@hash_func@@"},
       {-1, -1, 0, NULL},
-#line 367 "ext/Config/Config_xs.in"
+#line 375 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7023,	T_BOO,	0,"@@d_getprotobyname_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 979 "ext/Config/Config_xs.in"
+#line 987 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7027,		T_INT,	0,"@@longdblkind@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 716 "ext/Config/Config_xs.in"
+#line 724 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7036,		T_STR,	0,"@@doublenanbytes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 360 "ext/Config/Config_xs.in"
+#line 368 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7054,		T_BOO,	0,"@@d_getpbynumber@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 958 "ext/Config/Config_xs.in"
+#line 966 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7058,	T_STR,	0,"@@libdb_needs_pthread@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6264,13 +6272,13 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 224 "ext/Config/Config_xs.in"
+#line 232 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7128,	T_BOO,	0,"@@d_builtin_arith_overflow@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 770 "ext/Config/Config_xs.in"
+#line 778 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7135,	T_INT,	0,"@@getservbyname_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 870 "ext/Config/Config_xs.in"
+#line 878 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7142,		T_BOO,	0,"@@i_sysfilio@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6279,22 +6287,22 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 757 "ext/Config/Config_xs.in"
+#line 765 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7203,	T_INT,	0,"@@gethostbyaddr_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 755 "ext/Config/Config_xs.in"
+#line 763 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7233,	T_INT,	0,"@@getgrgid_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1283 "ext/Config/Config_xs.in"
+#line 1291 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7254,	T_STR,	0,"@@version_patchlevel_string@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 969 "ext/Config/Config_xs.in"
+#line 977 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7273,	T_STR,	0,"@@libswanted_uselargefiles@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6315,13 +6323,13 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1288 "ext/Config/Config_xs.in"
+#line 1296 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7444,		T_STR,	0,"@@yaccflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1264 "ext/Config/Config_xs.in"
+#line 1272 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7473,		T_STR,	0,"@@vendorarchexp@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6329,15 +6337,15 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 779 "ext/Config/Config_xs.in"
+#line 787 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7524,		T_STR,	0,"@@git_branch@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 953 "ext/Config/Config_xs.in"
+#line 961 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7553,	T_STR,	0,"@@ldflags_uselargefiles@@"},
-#line 211 "ext/Config/Config_xs.in"
+#line 219 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7554,	T_BOO,	0,"@@d_attribute_format@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6354,7 +6362,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 758 "ext/Config/Config_xs.in"
+#line 766 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7683,	T_INT,	0,"@@gethostbyname_r_proto@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6363,7 +6371,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 131 "ext/Config/Config_xs.in"
+#line 139 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7745,		T_STR,	0,"@@ccwarnflags@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6387,29 +6395,29 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 126 "ext/Config/Config_xs.in"
+#line 134 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7938,	T_STR,	0,"@@ccflags_uselargefiles@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 516 "ext/Config/Config_xs.in"
+#line 524 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str7974,		T_BOO,	0,"@@d_pwchange@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 1121 "ext/Config/Config_xs.in"
+#line 1129 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8003,		T_STR,	0,"@@sharpbang@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 796 "ext/Config/Config_xs.in"
+#line 804 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8009,		T_STR,	0,"@@h_sysfile@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 337 "ext/Config/Config_xs.in"
+#line 345 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8047,		T_BOO,	0,"@@d_gethbyaddr@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6422,7 +6430,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1031 "ext/Config/Config_xs.in"
+#line 1039 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8143,	T_INT,	0,"@@nv_preserves_uv_bits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6431,7 +6439,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1240 "ext/Config/Config_xs.in"
+#line 1248 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8200,	T_BOO,	0,"@@usensgetexecutablepath@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6451,7 +6459,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 705 "ext/Config/Config_xs.in"
+#line 713 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8356,		T_STR,	0,"@@db_prefixtype@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6467,16 +6475,16 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 217 "ext/Config/Config_xs.in"
+#line 225 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8478,	T_BOO,	0,"@@d_attribute_warn_unused_result@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL},
-#line 341 "ext/Config/Config_xs.in"
+#line 349 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8507,	T_BOO,	0,"@@d_gethostbyaddr_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 980 "ext/Config/Config_xs.in"
+#line 988 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8511,	T_INT,	0,"@@longdblmantbits@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6488,7 +6496,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 342 "ext/Config/Config_xs.in"
+#line 350 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8602,	T_BOO,	0,"@@d_gethostbyname_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6498,7 +6506,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 467 "ext/Config/Config_xs.in"
+#line 475 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8671,	T_BOO,	0,"@@d_modfl_pow32_bug@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6514,10 +6522,10 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 424 "ext/Config/Config_xs.in"
+#line 432 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8796,	T_BOO,	0,"@@d_libm_lib_version@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 380 "ext/Config/Config_xs.in"
+#line 388 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8804,	T_BOO,	0,"@@d_getservbyport_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6534,13 +6542,13 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 368 "ext/Config/Config_xs.in"
+#line 376 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8937,	T_BOO,	0,"@@d_getprotobynumber_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 379 "ext/Config/Config_xs.in"
+#line 387 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str8974,	T_BOO,	0,"@@d_getservbyname_r@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6558,10 +6566,10 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 1030 "ext/Config/Config_xs.in"
+#line 1038 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str9115,	T_STR,	0,"@@nv_overflows_integers_at@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 326 "ext/Config/Config_xs.in"
+#line 334 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str9118,	T_BOO,	0,"@@d_gdbm_ndbm_h_uses_prototypes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6594,7 +6602,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 978 "ext/Config/Config_xs.in"
+#line 986 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str9392,	T_STR,	0,"@@longdblinfbytes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6702,7 +6710,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 713 "ext/Config/Config_xs.in"
+#line 721 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str10343,		T_STR,	0,"@@doubleinfbytes@@"},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
@@ -6728,7 +6736,7 @@ Config_lookup (register const char *str, register unsigned int len)
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
       {-1, -1, 0, NULL}, {-1, -1, 0, NULL}, {-1, -1, 0, NULL},
-#line 981 "ext/Config/Config_xs.in"
+#line 989 "ext/Config/Config_xs.in"
       {(int)(long)&((struct stringpool_t *)0)->stringpool_str10554,	T_STR,	0,"@@longdblnanbytes@@"}
     };
 
@@ -6750,102 +6758,123 @@ Config_lookup (register const char *str, register unsigned int len)
     }
   return 0;
 }
-#line 1291 "ext/Config/Config_xs.in"
+#line 1299 "ext/Config/Config_xs.in"
 
-
-int g_iterpos = 0;
 
 MODULE = Config		PACKAGE = Config
 PROTOTYPES: DISABLE
 
-SV*
+void
 FETCH(self, key)
      SV* self
      SV* key
-CODE:
-     const struct Perl_Config *c = Config_lookup(SvPVX_const(key), SvCUR(key));
+PREINIT:
+     const struct Perl_Config *c;
+     SV * RETVAL;
+PPCODE:
+     SP++; /* make space for 1 returned SV* */
+     PUTBACK; /* let some vars go out of liveness */
+
+     c = Config_lookup(SvPVX_const(key), SvCUR(key));
      PERL_UNUSED_VAR(self);
      if (!c)
-         XSRETURN_UNDEF;
+         goto return_undef;
      if (c->type == T_EMP)
-         RETVAL = newSVpv_share("", 0);
-     else if (c->type == T_BOO)
-         RETVAL = *(c->value) == '0' ? &PL_sv_undef
-                                     : SvREFCNT_inc_NN(SV_CONST(define));
-     else if (c->type == T_INT)
+         RETVAL = &PL_sv_no;
+     else if (c->type == T_BOO) {
+         if(*(c->value) == '0')
+              return_undef:
+              RETVAL = &PL_sv_undef;
+         else
+              RETVAL = SV_CONST(define); /* this SV * never goes away once vivified */
+     }
+     else if (c->type == T_INT) {
 #ifdef HAS_STRTOL
          RETVAL = newSViv(strtol(c->value,NULL,10));
 #else
          RETVAL = newSViv(atoi(c->value));
 #endif
+         RETVAL = sv_2mortal(RETVAL);
+     }
      else
          /* TODO: store len also in struct */
-         RETVAL = newSVpvn(c->value, c->len);
-OUTPUT:
-    RETVAL
+         RETVAL = newSVpvn_flags(c->value, c->len, SVs_TEMP);
+     *SP = RETVAL;
+     return; /* skip implicit PUTBACK, it was done earlier */
 
+#1st argument is SV* self, but unused
 IV
-SCALAR(self = NULL)
-         SV *self
+SCALAR(...)
 CODE:
-    PERL_UNUSED_VAR(self);
+    /* This isn't accurate except for a bool test.
+       Should this actually be returning "1234/1234" where 1234 is
+       TOTAL_KEYWORDS? */
     /* Note: This is highly gperf dependent */
     RETVAL = TOTAL_KEYWORDS;
 OUTPUT:
     RETVAL
 
+# 1st arg could be self in the future
+# Note: KEYS doesnt exist in tied hash API, only FIRSTKEY/NEXTKEY
 void
-KEYS(self = NULL)
-         SV *self
+KEYS(...)
 PREINIT:
-    int i;
+    int i = 0;
     /* Note: This is highly gperf dependent */
     const int size = TOTAL_KEYWORDS;
-    char *s = (char *)stringpool;
+    const char *s = (const char *)stringpool;
+    const char * const end = (char *)stringpool+sizeof (stringpool_contents);
 PPCODE:
-    PERL_UNUSED_VAR(self);
     EXTEND(sp, size);
-    for (i=0; i<size; i++) {
+    while (s < end) {
         int l = strlen(s);
-        mPUSHp(s, l);
-        s += l+1;
+        const char * const current_s = s; /* reduce liveness of var l */
+        s += l+1; /* set string up for next read */
+        i++; /* sanity test */
+        mPUSHp(current_s, l);
     }
+    assert(i == size);
 
-SV*
-FIRSTKEY(self = NULL)
-         SV *self
+void
+FIRSTKEY(self)
+         CFGSELF *self
 PREINIT:
     /* Note: This is highly gperf dependent */
-    char *s = (char *)stringpool;
-CODE:
-    PERL_UNUSED_VAR(self);
-    g_iterpos = 0; /* self is a singleton */
-    RETVAL = newSVpvn(s, strlen(s));
-OUTPUT:
-    RETVAL
+    const char *s = (const char *)stringpool;
+    size_t len;
+PPCODE:
+    STATIC_ASSERT_STMT(sizeof (stringpool_contents) > 1); /* atleast 1 string */
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
 
-SV*
-NEXTKEY(self = NULL, lastkey = NULL)
-         SV *self
+    len = strlen(s);
+    /* self is SVIV with offset (aka iterator) into stringpool */
+    *self = len + 1; /* set to next string to read */
+    *SP = newSVpvn_flags(s, len, SVs_TEMP);
+    return; /* skip implicit PUTBACK, it was done earlier */
+
+void
+NEXTKEY(self, lastkey)
+         CFGSELF *self
          SV *lastkey
 PREINIT:
-    int i;
-    /* Note: This is highly gperf dependent */
-    const int size = TOTAL_KEYWORDS;
-    char *s = (char *)stringpool;
-CODE:
-    PERL_UNUSED_VAR(self);
+    SV * RETVAL;
+PPCODE:
     PERL_UNUSED_VAR(lastkey);
-    g_iterpos++;
-    if (g_iterpos >= size)
-        XSRETURN_UNDEF;
-    for (i=0; i<g_iterpos; i++) {
-        int l = strlen(s);
-        s += l+1;
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
+
+    /* bounds check to avoid running off the end of stringpool */
+    if (*self < sizeof (stringpool_contents)) {
+        const char * key = (const char*)stringpool+*self;
+        size_t len = strlen(key);
+        *self += len + 1;
+        RETVAL = newSVpvn_flags(key, len, SVs_TEMP);
     }
-    RETVAL = newSVpvn(s, strlen(s));
-OUTPUT:
-    RETVAL
+    else
+        RETVAL = &PL_sv_undef;
+    *SP = RETVAL;
+    return; /* skip implicit PUTBACK, it was done earlier */
 
 void
 EXISTS(self, key)

--- a/ext/Config/Config_xs.out
+++ b/ext/Config/Config_xs.out
@@ -82,11 +82,11 @@ API function to access the generated hash.
 
 /* Inside of tied XS object is a SVUV which is the iterator for the tied hash.
    The iterator is the offset of next stringpool string to read, unless the
-   iterating is done, then offset is beyond the end of stringpool and should
+   iterating is finished, then offset is beyond the end of stringpool and should
    not be used to deref (read) the string pool, until the next FIRSTKEY which
    resets the offset back to 0 or offset of 2nd string in string pool */
 
-typedef UV CFGSELF;
+typedef UV CFGSELF; /* for typemap */
 
 enum Config_types {
     T_EMP, /* "" */
@@ -6802,38 +6802,48 @@ PPCODE:
      *SP = RETVAL;
      return; /* skip implicit PUTBACK, it was done earlier */
 
-#1st argument is SV* self, but unused
-IV
-SCALAR(...)
-CODE:
-    /* This isn't accurate except for a bool test.
-       Should this actually be returning "1234/1234" where 1234 is
-       TOTAL_KEYWORDS? */
-    /* Note: This is highly gperf dependent */
-    RETVAL = TOTAL_KEYWORDS;
-OUTPUT:
-    RETVAL
+#you would think the prototype croak can be removed and replaced with ...
+#but the check actually makes sure there is 1 SP slot available since the retval
+#SV* winds up ontop of the incoming self arg
+void
+SCALAR(self)
+    SV *self
+PPCODE:
+    SP++; /* make space for 1 returned SV* */
+    PUTBACK; /* let some vars go out of liveness */
+    /* perfect hash is perfect */
+    *SP = newSVpvn_flags(STRINGIFY(TOTAL_KEYWORDS) "/" STRINGIFY(TOTAL_KEYWORDS),
+                         sizeof (STRINGIFY(TOTAL_KEYWORDS) "/" STRINGIFY(TOTAL_KEYWORDS))-1,
+                         SVs_TEMP);
+    return; /* skip implicit PUTBACK, it was done earlier */
 
 # 1st arg could be self in the future
 # Note: KEYS doesnt exist in tied hash API, only FIRSTKEY/NEXTKEY
 void
 KEYS(...)
 PREINIT:
-    int i = 0;
     /* Note: This is highly gperf dependent */
     const int size = TOTAL_KEYWORDS;
     const char *s = (const char *)stringpool;
     const char * const end = (char *)stringpool+sizeof (stringpool_contents);
 PPCODE:
-    EXTEND(sp, size);
-    while (s < end) {
-        int l = strlen(s);
-        const char * const current_s = s; /* reduce liveness of var l */
-        s += l+1; /* set string up for next read */
-        i++; /* sanity test */
-        mPUSHp(current_s, l);
-    }
-    assert(i == size);
+    const I32 gimme = GIMME_V;
+    if(gimme != G_VOID) {
+        EXTEND(sp,  gimme == G_SCALAR ? 1 : size);
+        if(gimme == G_SCALAR) {
+            mPUSHu(size); /* return just length */
+        } else {
+            int i = 0; /* optimized away */
+            while (s < end) {
+                int l = strlen(s);
+                const char * const current_s = s; /* reduce liveness of var l */
+                s += l+1; /* set string up for next read */
+                i++; /* sanity test */
+                mPUSHp(current_s, l);
+            }
+            assert(i == size);
+        }
+    } /* return nothing for void */
 
 void
 FIRSTKEY(self)

--- a/ext/Config/Config_xs.out
+++ b/ext/Config/Config_xs.out
@@ -95,7 +95,7 @@ enum Config_types {
     T_INT,
 };
 
-struct Perl_Config { int name; signed char type; size_t len; const char *value; };
+struct Perl_Config { U16 name; signed char type; size_t len; const char *value; };
 static const struct Perl_Config *
 Config_lookup (register const char *str, register unsigned int len);
 
@@ -6763,6 +6763,11 @@ Config_lookup (register const char *str, register unsigned int len)
 
 MODULE = Config		PACKAGE = Config
 PROTOTYPES: DISABLE
+
+BOOT:
+{
+    STATIC_ASSERT_STMT(sizeof (stringpool_contents) <= U16_MAX);
+}
 
 void
 FETCH(self, key)

--- a/ext/Config/Makefile.PL
+++ b/ext/Config/Makefile.PL
@@ -3,6 +3,11 @@ WriteMakefile(
     'NAME'		=> 'Config',
     'VERSION_FROM'	=> 'Config.pm',
     'PL_FILES'		=> {'Config_xs.PL' => 'Config.xs'},
+    #TODO backdate the modify timestamp on Config.pm to old Config.pm
+    #'PM' => {
+    #    'Config.pm'      => '$(INST_LIBDIR)/Config.pm'
+    #},
+    #XSOPT  => ' -nolinenumbers ',
 );
 
 package MY;

--- a/ext/Config/typemap
+++ b/ext/Config/typemap
@@ -1,0 +1,10 @@
+CFGSELF *   T_XSCFGSELF
+
+INPUT
+
+#internals of object is private so skip SV checks
+T_XSCFGSELF
+	{SV * TmpSVRV = $arg;
+	assert(SvROK(TmpSVRV) && SvIOK(SvRV(TmpSVRV)));
+	/* compute UV * once, no multiple ptr derefs on each r/w */
+	$var = &SvUVX(SvRV(TmpSVRV));};

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '0.73';
+our $VERSION = '0.73_01c';
 
 require XSLoader;
 

--- a/ext/XS-APItest/APItest.xs
+++ b/ext/XS-APItest/APItest.xs
@@ -1914,6 +1914,30 @@ xop_from_custom_op ()
     OUTPUT:
         RETVAL
 
+bool
+test_sv_debug_members()
+CODE:
+#ifdef HAS_ANONFIELDS
+    if(STRUCT_OFFSET(SV,sv_any) == STRUCT_OFFSET(SV,sv_any_dbg._1_5iv)) {
+        SV * sv =  newSV(0);
+        if(!cBOOL(SvTEMP(sv)) && !sv->sv_flags_dbg.s_TEMP) {
+            sv_2mortal(sv);
+            if(cBOOL(SvTEMP(sv)) && sv->sv_flags_dbg.s_TEMP){
+                RETVAL = TRUE;
+                goto end;
+            }
+        } else { /* has to be freed even if failed */
+            sv_2mortal(sv);
+        }
+    }
+    RETVAL = FALSE;
+#else
+    RETVAL = TRUE; /* nothing to test, members don't exist */
+#endif
+    end:
+OUTPUT:
+    RETVAL
+
 BOOT:
 {
     MY_CXT_INIT;

--- a/ext/XS-APItest/t/svpv.t
+++ b/ext/XS-APItest/t/svpv.t
@@ -1,8 +1,10 @@
 #!perl -w
 
-use Test::More tests => 19;
+use Test::More tests => 20;
 
 use XS::APItest;
+
+ok(XS::APItest::test_sv_debug_members(), "debugging SV union members work");
 
 for my $func ('SvPVbyte', 'SvPVutf8') {
  $g = *glob;

--- a/handy.h
+++ b/handy.h
@@ -2148,6 +2148,15 @@ void Perl_mem_log_del_sv(const SV *sv, const char *filename, const int linenumbe
 
 #endif
 
+/* useful inside another macro */
+#ifdef USE_CPERL
+#  define USE_CPERL_EXPR(a) a
+#  define USE_NO_CPERL_EXPR(a)
+#else
+#  define USE_CPERL_EXPR(a)
+#  define USE_NO_CPERL_EXPR(a) a
+#endif
+
 #endif  /* HANDY_H */
 
 /*

--- a/pod/.gitignore
+++ b/pod/.gitignore
@@ -54,6 +54,8 @@
 
 # generated
 /perl5222delta.pod
+/perl5222cdelta.pod
+/perl5230delta.pod
 /perlapi.pod
 /perlintern.pod
 *.html

--- a/pod/.gitignore
+++ b/pod/.gitignore
@@ -53,7 +53,6 @@
 /roffitall
 
 # generated
-/perl5222delta.pod
 /perl5222cdelta.pod
 /perl5230delta.pod
 /perlapi.pod

--- a/sv.h
+++ b/sv.h
@@ -202,7 +202,7 @@ typedef struct hek HEK;
 	union {			\
 	    XPVIV * _1_5iv;	\
 	    XPVNV * _2_6nv;	\
-	    XPV * _3pv;		\
+	    XPV   * _3pv;	\
 	    XINVLIST * _4invl;	\
 	    XPVMG * _7mg;	\
 	    struct regexp *_8rx;\

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -257,6 +257,8 @@ typedef unsigned short	mode_t;
 #  pragma intrinsic(_rotl64,_rotr64)
 #endif
 
+#define HAS_ANONFIELDS
+
 #  pragma warning(push)
 #  pragma warning(disable:4756;disable:4056)
 PERL_STATIC_INLINE


### PR DESCRIPTION
A WIP on cleaning up XS Config. possibly for CPAN. Most notable fix is it turns "keys %Config" from (N^2) to an (N) operation, There are some bugs with mini Config.pm not acting right I will address in another ticket. And Win64 builds blew up completely (mass test fails) due to wrong "byteorder", something to do with XS Config but i not at my Win64 box rite now, that will get another ticket.

"add unions & bitfield to SV for easier dump analysis" is a P5P rejected patch that allows you to examine perl SV *s using your IDE's watch/expression window, you get to click on +s to drill down deep into sv bodies and heads and magic LLs. I can' tbreath without this rejected P5P patch.
