### PR TITLE
Config: test PP Config vs XS Config to make sure they are equal

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3588,6 +3588,7 @@ ext/Config/Config_xs.out	gperf expanded Config.xs template with empty values
 ext/Config/Config_xs.PL		Update Config.xs and Config_xs.in
 ext/Config/Dummy.c		XS Config empty C file
 ext/Config/Makefile.PL		XS Config extension makefile writer
+ext/Config/t/Config.t		XS Config extension tests
 ext/Config/typemap		XS Config extension typemap
 ext/Devel-Peek/Changes		Data debugging tool, changelog
 ext/Devel-Peek/Peek.pm		Data debugging tool, module and pod

--- a/Porting/Maintainers.pl
+++ b/Porting/Maintainers.pl
@@ -229,6 +229,7 @@ use File::Glob qw(:case);
                  ext/Config/Config_xs.{in,out,PL}
                  ext/Config/Dummy.c
                  ext/Config/Makefile.PL
+                 ext/Config/t/Config.t
                  ext/Config/typemap
         ],
     },

--- a/ext/Config/t/Config.t
+++ b/ext/Config/t/Config.t
@@ -1,0 +1,40 @@
+    die "Config can't be permanent" if keys %Config::;
+    require Config; #this is supposed to be XS config
+    require B;
+    my $cv = B::svref_2object(*{'Config::FETCH'}{CODE});
+    die "Config:: is not XS Config" unless $cv->CvFLAGS() & B::CVf_ISXSUB();
+
+    #change the class name of XS Config so there can be XS and PP Config at same time
+    foreach(qw( TIEHASH DESTROY DELETE CLEAR EXISTS NEXTKEY FIRSTKEY KEYS SCALAR FETCH)) {
+        *{'XSConfig::'.$_} = *{'Config::'.$_}{CODE};
+    }
+    tie(%XSConfig, 'XSConfig');
+    #delete package
+    undef( *main::Config:: );
+    require Data::Dumper;
+    $Data::Dumper::Sortkeys = 1;
+    $Data::Dumper::Useqq = 1;
+    #full perl is now miniperl
+    undef( *main::XSLoader::);
+    require 'Config_mini.pl';
+    Config->import();
+    require Test::More;
+    Test::More->import(tests => 3);
+
+    $cv = B::svref_2object(*{'Config::FETCH'}{CODE});
+    ok(($cv->CvFLAGS() & B::CVf_ISXSUB()) == 0, 'PP Config:: is PP');
+    my($klenPP, $klenXS) = (scalar(keys %Config), scalar(keys %XSConfig));
+    is($klenXS, $klenPP, 'key count same');
+    is_deeply(\%XSConfig, \%Config, "cmp hashes");
+    if(!Test::More->builder->is_passing){
+        open(F, '>','xscfg.txt');
+        print F Data::Dumper::Dumper({%XSConfig});
+        close F;
+        open(G, '>', 'ppcfg.txt');
+        print G Data::Dumper::Dumper({%Config});
+        close G;
+        system('diff -u ppcfg.txt xscfg.txt');
+        unlink('xscfg.txt');
+        unlink('ppcfg.txt');
+    }
+

--- a/ext/Config/t/Config.t
+++ b/ext/Config/t/Config.t
@@ -38,3 +38,4 @@
         unlink('ppcfg.txt');
     }
 
+

--- a/ext/Config/t/Config.t
+++ b/ext/Config/t/Config.t
@@ -33,9 +33,16 @@
         open(G, '>', 'ppcfg.txt');
         print G Data::Dumper::Dumper({%Config});
         close G;
-        system('diff -u ppcfg.txt xscfg.txt');
+        system('diff -u ppcfg.txt xscfg.txt > cfg.diff');
         unlink('xscfg.txt');
         unlink('ppcfg.txt');
+        {   open H , '<','cfg.diff';
+            $/ = undef;
+            my $file = <H>;
+            die "bad" if ! length $file;
+            diag($file);
+        }
+        
     }
 
 


### PR DESCRIPTION
This helps towards a cpan release of XS Config.

This is part of #61 note it reveals not only different values for keys, but extra keys, the 2 are supposed to be mirror images more or less.

Note the failures in the travis. The 2 Configs aren't identical in keys or values which needs to be resolved somehow.
