### PR TITLE
Config: length(undef) is not 0

### DIFF
--- a/ext/Config/Config_xs.PL
+++ b/ext/Config/Config_xs.PL
@@ -202,12 +202,11 @@ while (<$in>) {
         my $v = $h{$k};
         my $qv = $v;
         $qv =~ s/(\\[nrftacx ])/\\$1/g; # \n => \\n
-        my $l = length $v;
-        if ($v =~ m/["'\\]/) {
+        my $l =  $v =~ m/["'\\]/ ?
           # don't calculate C-style length [cperl #61], let C do it for us
           # and don't count the ending \0
-          $l = 'sizeof ("' . $qv . '")-1';
-        }
+            'sizeof ("' . $qv . '")-1'
+          : length($v)+0;
         my $qr = "0,\"@@".$k."@@\"";
         my $new = $l . ', "' . $qv . '"';
         s/$qr/$new/; # we have one line per key only


### PR DESCRIPTION
This fixes a Win32 C syntax error while building XS Config.

ext/Config/Config_xs.in(957) : error C2059: syntax error : ','
ext/Config/Config_xs.in(411) : fatal error C1013: compiler limit : too many open
 parentheses
dmake:  Error code 130, while making 'Config.obj'
Unsuccessful make(ext/Config): code=65280 at ..\make_ext.pl line 575.
dmake:  Error code 130, while making 'Extensions'

fault line in Config.c
# line 957 "ext/Config/Config_xs.in"

```
  {(U16)(long)&((struct stringpool_t *)0)->stringpool_str1008,      T_EMP,  , ""}, /* ld_can_script */
```
