### PR TITLE
B-C fixes comments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ branches:
     - /smoke/
 init:
   - git config --global core.autocrlf input
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 # from https://github.com/apache/lucy-clownfish/blob/master/appveyor.yml  
 build: off

--- a/configpm
+++ b/configpm
@@ -862,15 +862,9 @@ $config_txt .= sprintf <<'ENDOFTIE', $fast_config;
 sub DESTROY { }
 
 sub AUTOLOAD {
-    if (defined &XSLoader::load) {
-        no warnings 'redefine';
-        XSLoader::load('Config', $VERSION);
-        return Config->FETCH($_[0]);
-    } else {
-        require 'Config_heavy.pl';
-        goto \&launcher unless $Config::AUTOLOAD =~ /launcher$/;
-        die "&Config::AUTOLOAD failed on $Config::AUTOLOAD";
-    }
+    require 'Config_heavy.pl';
+    goto \&launcher unless $Config::AUTOLOAD =~ /launcher$/;
+    die "&Config::AUTOLOAD failed on $Config::AUTOLOAD";
 }
 
 # tie returns the object, so the value returned to require will be true.

--- a/cpan/B-C/lib/B/C.pm
+++ b/cpan/B-C/lib/B/C.pm
@@ -7344,10 +7344,11 @@ _EOT9
                 $sofile = "$modlibname/auto/$modpname/$modfname.".$Config{dlext};
               }
               #warn "load_file: $stashname, $stashfile, $sofile";
-              printf "\tmXPUSHp(\"%s\", %d);\n", $sofile, length($sofile);
-            } else {
-              printf "\tmXPUSHp(\"%s\", %d);\n", $stashfile, length($stashfile);
+              $stashfile = $sofile;
             }
+            my $stashfile_len = length($stashfile);
+            $stashfile =~ s/(\\[^nrftacx"' ])/\\$1/g; # windows paths: \\ => \\\\
+            printf "\tmXPUSHp(\"%s\", %d);\n", $stashfile, $stashfile_len;
 	  }
 	  print "\tPUTBACK;\n";
 	  warn "bootstrapping $stashname added to XSLoader dl_init\n" if $verbose;

--- a/cpan/B-C/lib/B/C.pm
+++ b/cpan/B-C/lib/B/C.pm
@@ -7122,7 +7122,7 @@ static void
 xs_init(pTHX)
 {
 	char *file = __FILE__;
-	dTARG; dSP;
+	dTARG; dSP; CV * cv;
 _EOT8
   if ($CPERL51 and $debug{cv}) {
     print q{
@@ -7134,9 +7134,6 @@ _EOT8
   #if ($staticxs) { #FIXME!
   #  print "\n#undef USE_DYNAMIC_LOADING
   #}
-  print "\n#ifdef USE_DYNAMIC_LOADING";
-  print "\n\tnewXS(\"DynaLoader::boot_DynaLoader\", boot_DynaLoader, file);";
-  print "\n#endif\n";
 
   delete $xsub{'DynaLoader'};
   delete $xsub{'UNIVERSAL'};
@@ -7156,11 +7153,8 @@ _EOT8
   printf "\tXPUSHp(\"DynaLoader\", %d);\n", length("DynaLoader");
   print "\tPUTBACK;\n";
   warn "bootstrapping DynaLoader added to xs_init\n" if $verbose;
-  if ($PERL522) {
-    print "\tboot_DynaLoader(aTHX_ get_cv(\"DynaLoader::bootstrap\", GV_ADD));\n";
-  } else {
-    print "\tboot_DynaLoader(aTHX_ NULL);\n";
-  }
+  print "\tcv = newXS(\"DynaLoader::boot_DynaLoader\", boot_DynaLoader, file);\n";
+  print "\tboot_DynaLoader(aTHX_ cv);\n";
   print "\tSPAGAIN;\n";
   if ($CPERL51 and $^O ne 'MSWin32') {
     print "\tdl_boot(aTHX);\n";

--- a/t/appveyor-smoke.bat
+++ b/t/appveyor-smoke.bat
@@ -14,7 +14,7 @@ if "%PLATFORM%" == "X64" ( set "PATH=C:\windows\system32;C:\Program Files (x86)\
 
 cd win32
 nmake CCTYPE=MSVC120 USE_NO_REGISTRY=define
-nmake test CCTYPE=MSVC120 USE_NO_REGISTRY=define TEST_JOBS=4 || exit /b
+nmake test CCTYPE=MSVC120 USE_NO_REGISTRY=define || exit /b
 exit /b
 
 :msvc_10
@@ -23,5 +23,5 @@ if "%PLATFORM%" == "x64" ( set "PATH=C:\windows\system32;c:\Program Files (x86)\
 
 cd win32
 nmake CCTYPE=MSVC100 USE_NO_REGISTRY=define
-nmake test CCTYPE=MSVC100 USE_NO_REGISTRY=define TEST_JOBS=4 || exit /b
+nmake test CCTYPE=MSVC100 USE_NO_REGISTRY=define || exit /b
 exit /b


### PR DESCRIPTION
How dl_boot() is reached in a BC proc.

```
    cperl524.dll!dl_generic_private_init(interpreter * my_perl=0x0037437c)  Line 162    C
    cperl524.dll!dl_private_init(interpreter * my_perl=0x0037437c)  Line 63 + 0x9   C
    cperl524.dll!boot_DynaLoader(interpreter * my_perl=0x0037437c, cv * cv=0x008fd41c)  Line 116 + 0x9  C
    pcc.exe!xs_init(interpreter * my_perl=0x0037437c)  Line 2300 + 0x1e C
    cperl524.dll!S_parse_body(interpreter * my_perl=0x0037437c, char * * env=0x00373490, void (interpreter *)* xsinit=0x00401aa0)  Line 2307 + 0x7  C
    cperl524.dll!perl_parse(interpreter * my_perl=0x0037437c, void (interpreter *)* xsinit=0x00401aa0, int argc=4, char * * argv=0x0037fde4, char * * env=0x00373490)  Line 1661 + 0x11 C
    pcc.exe!main(int argc=1, char * * argv=0x00374328, char * * env=0x00373490)  Line 2402 + 0x22   C
    pcc.exe!__tmainCRTStartup()  Line 586 + 0x17    C
    kernel32.dll!_BaseProcessStart@4()  + 0x23
```

xs_init in a BC Proc

```
/* yanked from perl.c */
static void
xs_init(pTHX)
{
    char *file = __FILE__;
    dTARG; dSP;

#ifdef USE_DYNAMIC_LOADING
    newXS("DynaLoader::boot_DynaLoader", boot_DynaLoader, file);
#endif
/* XS bootstrapping code*/
    SAVETMPS;
    targ=sv_newmortal();
    newXS("Win32CORE::bootstrap", boot_Win32CORE, file);
#ifdef USE_DYNAMIC_LOADING
    PUSHMARK(sp);
    XPUSHp("DynaLoader", 10);
    PUTBACK;
    boot_DynaLoader(aTHX_ get_cv("DynaLoader::bootstrap", GV_ADD));
    SPAGAIN;
#endif
    FREETMPS;
/* end XS bootstrapping code */
}
```

xs_init in cperl core

```
static void
xs_init(pTHX)
{
    const char *file = __FILE__;
    dSP;
    CV *cv = newXS("DynaLoader::boot_DynaLoader", boot_DynaLoader, file);
    dXSUB_SYS;
    /* With cperl boot it now immediately */
    PUSHMARK(SP);
    boot_DynaLoader(aTHX_ cv);

    /* other similar records will be included from "perllibst.h" */
#define STATIC3
#include "perllibst.h"
}
```

Note that boot_DynaLoader XSUB's proper name is "DynaLoader::boot_DynaLoader" but that
"get_cv("DynaLoader::bootstrap", GV_ADD)" is improper and creates a sub. That sub later causes

```
static void
dl_generic_private_init(pTHX)   /* called by dl_*.xs dl_private_init() */
{
#if defined(PERL_IN_DL_HPUX_XS) || defined(PERL_IN_DL_DLOPEN_XS)
    char *perl_dl_nonlazy;
    UV uv;
#endif
    MY_CXT_INIT;

    MY_CXT.x_dl_last_error = newSVpvs("");
#ifdef DL_LOADONCEONLY
    dl_loaded_files = NULL;
#endif
////////////CUT//////////////
#ifdef DL_LOADONCEONLY
    if (!dl_loaded_files)
#else
    if (!get_cv("DynaLoader::bootstrap", 0))
#endif
      dl_boot(aTHX);
}
```

the get_cv to return true, then dl_boot() never executes, and XSLoader::load_file() is never registered/newXSed. Eventually the BC proc does

```
static void
dl_init(pTHX)
{
    char *file = __FILE__;
    dTARG; dSP;
/* DynaLoader bootstrapping */
    ENTER;
    ++cxstack_ix; cxstack[cxstack_ix].blk_oldcop = PL_curcop;
    /* assert(cxstack_ix == 0); */
    SAVETMPS;

    PUSHMARK(sp);
    mXPUSHp("Config", 6);
#ifndef STATICXS
    mXPUSHp("..\..\lib/auto/Config/Config.dll", 32);
    PUTBACK;
    call_pv("XSLoader::load_file", G_VOID|G_DISCARD);
#else
    PUTBACK;
```

The call_pv throws an exeception, but there is no eval frame.

```
    ntdll.dll!7c90120e()    
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 850    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a0a4)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281ed284, char * * args=0x0012fd84)  Line 1777    C
    cperl524.dll!Perl_die(interpreter * my_perl=0x0037437c, const char * pat=0x281ed284, ...)  Line 1709    C
    cperl524.dll!Perl_pp_entersub(interpreter * my_perl=0x0037437c)  Line 3959 + 0x12   C
    cperl524.dll!Perl_call_sv(interpreter * my_perl=0x0037437c, sv * sv=0x00909ff4, volatile long flags=5)  Line 2860 + 0x17    C
    cperl524.dll!Perl_call_pv(interpreter * my_perl=0x0037437c, const char * sub_name=0x0040abb4, long flags=5)  Line 2739 + 0x20   C
    pcc.exe!dl_init(interpreter * my_perl=0x0037437c)  Line 2325 + 0x11 C
    pcc.exe!main(int argc=1, char * * argv=0x00374328, char * * env=0x00373490)  Line 2424 + 0x9    C
    pcc.exe!__tmainCRTStartup()  Line 586 + 0x17    C
    kernel32.dll!_BaseProcessStart@4()  + 0x23  
```

Since there is no eval frame, perl panics with "panic: corrupt saved stack index -1414812757." and -1414812757 happens to be 0xabababab, a malloc memory fill pattern. This causes infinite recursion.

```
    ntdll.dll!7c90120e()    
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 850    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a124)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, char * * args=0x0012f704)  Line 1777    C
    cperl524.dll!Perl_croak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, ...)  Line 1823  C
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 854    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a104)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, char * * args=0x0012f8a4)  Line 1777    C
    cperl524.dll!Perl_croak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, ...)  Line 1823  C
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 854    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a0e4)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, char * * args=0x0012fa44)  Line 1777    C
    cperl524.dll!Perl_croak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, ...)  Line 1823  C
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 854    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a0c4)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, char * * args=0x0012fbe4)  Line 1777    C
    cperl524.dll!Perl_croak(interpreter * my_perl=0x0037437c, const char * pat=0x281f4d10, ...)  Line 1823  C
    cperl524.dll!Perl_leave_scope(interpreter * my_perl=0x0037437c, long base=-1414812757)  Line 854    C
    cperl524.dll!Perl_dounwind(interpreter * my_perl=0x0037437c, long cxix=-1)  Line 1543 + 0x1e    C
    cperl524.dll!S_my_exit_jump(interpreter * my_perl=0x0037437c)  Line 5242 + 0xb  C
    cperl524.dll!Perl_my_failure_exit(interpreter * my_perl=0x0037437c)  Line 5230  C
    cperl524.dll!Perl_die_unwind(interpreter * my_perl=0x0037437c, sv * msv=0x0090a0a4)  Line 1740  C
    cperl524.dll!Perl_vcroak(interpreter * my_perl=0x0037437c, const char * pat=0x281ed284, char * * args=0x0012fd84)  Line 1777    C
    cperl524.dll!Perl_die(interpreter * my_perl=0x0037437c, const char * pat=0x281ed284, ...)  Line 1709    C
    cperl524.dll!Perl_pp_entersub(interpreter * my_perl=0x0037437c)  Line 3959 + 0x12   C
    cperl524.dll!Perl_call_sv(interpreter * my_perl=0x0037437c, sv * sv=0x00909ff4, volatile long flags=5)  Line 2860 + 0x17    C
    cperl524.dll!Perl_call_pv(interpreter * my_perl=0x0037437c, const char * sub_name=0x0040abb4, long flags=5)  Line 2739 + 0x20   C
    pcc.exe!dl_init(interpreter * my_perl=0x0037437c)  Line 2325 + 0x11 C
    pcc.exe!main(int argc=1, char * * argv=0x00374328, char * * env=0x00373490)  Line 2424 + 0x9    C
    pcc.exe!__tmainCRTStartup()  Line 586 + 0x17    C
    kernel32.dll!_BaseProcessStart@4()  + 0x23  
```

until the C stack is exhausted.

backslashes must be escaped or else this happens with VC

```
pccm3YRM.c(104821) : warning C4129: '.' : unrecognized character escape sequence
pccm3YRM.c(104821) : warning C4129: 'l' : unrecognized character escape sequence
```
