### PR TITLE
Fix the EUMM test suite in cross-compil environment

### DIFF
--- a/dist/ExtUtils-MakeMaker/t/INSTALL_BASE.t
+++ b/dist/ExtUtils-MakeMaker/t/INSTALL_BASE.t
@@ -15,12 +15,13 @@ $CLEANUP &&= 1; # so always 1 or numerically 0
 
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
-use Test::More;
 use Config;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 3 + $CLEANUP + @INSTDIRS * (15 + $CLEANUP));
+    : ();
+plan tests => 3 + $CLEANUP + @INSTDIRS * (15 + $CLEANUP);
 
 my $Is_VMS = $^O eq 'VMS';
 

--- a/dist/ExtUtils-MakeMaker/t/PL_FILES.t
+++ b/dist/ExtUtils-MakeMaker/t/PL_FILES.t
@@ -11,9 +11,9 @@ use File::Temp qw[tempdir];
 use MakeMaker::Test::Setup::PL_FILES;
 use MakeMaker::Test::Utils;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 9);
 

--- a/dist/ExtUtils-MakeMaker/t/basic.t
+++ b/dist/ExtUtils-MakeMaker/t/basic.t
@@ -20,9 +20,9 @@ use utf8;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 171);
 use File::Find;

--- a/dist/ExtUtils-MakeMaker/t/min_perl_version.t
+++ b/dist/ExtUtils-MakeMaker/t/min_perl_version.t
@@ -13,9 +13,9 @@ use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::MPV;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 36);
 use File::Path;

--- a/dist/ExtUtils-MakeMaker/t/pm_to_blib.t
+++ b/dist/ExtUtils-MakeMaker/t/pm_to_blib.t
@@ -12,9 +12,9 @@ use ExtUtils::MakeMaker;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : 'no_plan';
 

--- a/dist/ExtUtils-MakeMaker/t/recurs.t
+++ b/dist/ExtUtils-MakeMaker/t/recurs.t
@@ -14,9 +14,9 @@ use File::Temp qw[tempdir];
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::Recurs;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 26);
 

--- a/dist/ExtUtils-MakeMaker/t/several_authors.t
+++ b/dist/ExtUtils-MakeMaker/t/several_authors.t
@@ -13,9 +13,9 @@ use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::SAS;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 20);
 use File::Path;


### PR DESCRIPTION
The EUMM test suite fails in cross-compil environment, like this: 
```
$ ./perl harness -v ../dist/ExtUtils-MakeMaker/t/basic.t
../dist/ExtUtils-MakeMaker/t/basic.t .. No root path(s) specified
 at t/basic.t line 79.

1..0 # SKIP cross-compiling and make not available
ok 1
ok 2 - teardown# Tests were run but no plan was declared and done_testing() was not seen.

skipped: cross-compiling and make not available
```
This commit restores the implicit call of `plan()` at import time of `Test::More`

See https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/4a07a3bd18363986112cf2b39dec3c2985353ffb