### PR TITLE
fix Config_lookup prototype for gperf-3.1

### DIFF
--- a/ext/Config/Config_xs.in
+++ b/ext/Config/Config_xs.in
@@ -225,7 +225,7 @@ struct Perl_Config { U16 name : 15; U16 type : 1; U16 len; const char *value; };
 #endif
 
 static const struct Perl_Config *
-Config_lookup (register const char *str, register unsigned int len);
+Config_lookup ();
 
 %}
 %language=ANSI-C


### PR DESCRIPTION
ext/Config/Config_xs.in declares `Config_lookup` like this:

    static const struct Perl_Config *
    Config_lookup (register const char *str, register unsigned int len);

gperf-3.0.4 generate a matching body for this function:

    const struct Perl_Config *
    Config_lookup (register const char *str, register unsigned int len)

but gperf-3.1 replaces `unsigned int` with `size_t`, breaking builds for 64-bit targets:

    const struct Perl_Config *
    Config_lookup (register const char *str, register size_t len)

It looks like the prototype is only there to make it `static`, so omitting arguments should not break anything.