### PR TITLE
Always include dist/if in @toolchain

### DIFF
--- a/write_buildcustomize.pl
+++ b/write_buildcustomize.pl
@@ -44,6 +44,7 @@ my @toolchain = qw(cpan/AutoLoader/lib
 		   cpan/Pod-Escapes/lib
 		   cpan/Getopt-Long/lib
 		   cpan/File-Path/lib
+		   dist/if
 		   );
 
 # Text-ParseWords used only in ExtUtils::Liblist::Kid::_win32_ext()
@@ -53,7 +54,6 @@ push @toolchain, qw(
 	cpan/Text-ParseWords/lib
 	dist/ExtUtils-ParseXS/lib
 	cpan/parent/lib
-        dist/if
 	dist/ExtUtils-Constant/lib
 ) if $^O eq 'MSWin32';
 push @toolchain, 'ext/VMS-Filespec/lib' if $^O eq 'VMS';


### PR DESCRIPTION
As https://www.reddit.com/r/cperl/comments/en9t0a/building_cperl5300_compilation_problem/ explains, "dist/if" must be included in toolchain not only with a push in the case 'MSWin32' but also for other systems. Otherwise, cperl won't compile under some Linuxes.

This change allows cperl to compile under those Linuxes (e.g., Void Linux).